### PR TITLE
Renamed district to surroundings

### DIFF
--- a/src/renderer/components/InputEditor/Table.js
+++ b/src/renderer/components/InputEditor/Table.js
@@ -211,9 +211,9 @@ const Table = ({ tab }) => {
         {!data.length ? (
           <div>
             Input file could not be found. You can create the file using
-            {tab == 'district' ? (
-              <Link to={`${routes.TOOLS}/distict-helper`}>
-                {' distict-helper '}
+            {tab == 'surroundings' ? (
+              <Link to={`${routes.TOOLS}/surroundings-helper`}>
+                {' surroundings-helper '}
               </Link>
             ) : (
               <Link to={`${routes.TOOLS}/data-helper`}>{' data-helper '}</Link>

--- a/src/renderer/components/Map/Map.js
+++ b/src/renderer/components/Map/Map.js
@@ -54,7 +54,7 @@ const DeckGLMap = ({ data, colors }) => {
   const [extruded, setExtruded] = useState(false);
   const [visibility, setVisibility] = useState({
     zone: !!data.zone,
-    district: !!data.district,
+    surroundings: !!data.surroundings,
     streets: !!data.streets,
     dc: !!data.dc,
     dh: !!data.dh && !data.dc,
@@ -115,22 +115,22 @@ const DeckGLMap = ({ data, colors }) => {
         })
       );
     }
-    if (data.district) {
+    if (data.surroundings) {
       _layers.push(
         new GeoJsonLayer({
-          id: 'district',
-          data: data.district,
+          id: 'surroundings',
+          data: data.surroundings,
           opacity: 0.5,
           wireframe: true,
           filled: true,
           extruded: extruded,
-          visible: visibility.district,
+          visible: visibility.surroundings,
 
           getElevation: f => f.properties['height_ag'],
           getFillColor: f =>
             buildingColor(
               f.properties['Name'],
-              'district',
+              'surroundings',
               colors,
               connectedBuildings[network_type],
               selected,
@@ -354,17 +354,17 @@ const LayerToggle = ({ data, setVisibility }) => {
           </label>
         </span>
       )}
-      {data.district && (
+      {data.surroundings && (
         <span className="layer-toggle">
           <label className="map-plot-label">
             <input
               type="checkbox"
               name="layer-toggle"
-              value="district"
+              value="surroundings"
               onChange={handleChange}
               defaultChecked
             />
-            District
+            Surroundings
           </label>
         </span>
       )}
@@ -408,7 +408,7 @@ function updateTooltip({ x, y, object, layer }) {
     tooltip.style.left = `${x}px`;
     let innerHTML = '';
 
-    if (layer.id === 'zone' || layer.id === 'district') {
+    if (layer.id === 'zone' || layer.id === 'surroundings') {
       Object.keys(properties).forEach(key => {
         innerHTML += `<div><b>${key}</b>: ${properties[key]}</div>`;
       });
@@ -462,7 +462,7 @@ const buildingColor = (
   if (selected.includes(buildingName)) {
     return [255, 255, 0, 255];
   }
-  if (layer === 'district') return colors.district;
+  if (layer === 'surroundings') return colors.surroundings;
   if (connectedBuildings.includes(buildingName)) return colors[network_type];
   return colors.disconnected;
 };

--- a/src/renderer/components/Project/NewScenarioModal.js
+++ b/src/renderer/components/Project/NewScenarioModal.js
@@ -162,7 +162,7 @@ const ScenarioGenerateDataForm = ({ form, visible }) => {
   const [selectedTool, setSelectedTool] = useState(null);
   const tools = form.getFieldValue('tools') || [];
   const zoneChecked = tools.includes('zone');
-  const districtChecked = tools.includes('district');
+  const surroundingsChecked = tools.includes('surroundings');
 
   const showModal = tool => {
     setSelectedTool(tool);
@@ -170,7 +170,7 @@ const ScenarioGenerateDataForm = ({ form, visible }) => {
   };
 
   const handleChange = checkedValue => {
-    if (!checkedValue.includes('district')) {
+    if (!checkedValue.includes('surroundings')) {
       setTimeout(() => {
         form.setFieldsValue({
           tools: checkedValue.filter(
@@ -215,12 +215,12 @@ const ScenarioGenerateDataForm = ({ form, visible }) => {
 
             <div style={{ margin: 10 }}>
               <Row>
-                <Checkbox value="district" disabled={!zoneChecked}>
-                  District
+                <Checkbox value="surroundings" disabled={!zoneChecked}>
+                  Surroundings
                 </Checkbox>
                 <Icon
                   type="setting"
-                  onClick={() => showModal('district-helper')}
+                  onClick={() => showModal('surroundings-helper')}
                 />
                 <small
                   style={{
@@ -232,12 +232,14 @@ const ScenarioGenerateDataForm = ({ form, visible }) => {
                   *Requires zone file.
                 </small>
               </Row>
-              <small>- Query district geometry from Open Street Maps.</small>
+              <small>
+                - Query Surroundings geometry from Open Street Maps.
+              </small>
             </div>
 
             <div style={{ margin: 10 }}>
               <Row>
-                <Checkbox value="streets" disabled={!districtChecked}>
+                <Checkbox value="streets" disabled={!surroundingsChecked}>
                   Streets
                 </Checkbox>
                 <Icon
@@ -248,10 +250,10 @@ const ScenarioGenerateDataForm = ({ form, visible }) => {
                   style={{
                     color: 'red',
                     marginLeft: 10,
-                    display: districtChecked ? 'none' : ''
+                    display: surroundingsChecked ? 'none' : ''
                   }}
                 >
-                  *Requires zone and district file.
+                  *Requires zone and surroundings file.
                 </small>
               </Row>
               <small>- Query streets geometry from Open Street Maps.</small>
@@ -259,7 +261,7 @@ const ScenarioGenerateDataForm = ({ form, visible }) => {
 
             <div style={{ margin: 10 }}>
               <Row>
-                <Checkbox value="terrain" disabled={!districtChecked}>
+                <Checkbox value="terrain" disabled={!surroundingsChecked}>
                   Terrain
                 </Checkbox>
                 <Icon
@@ -270,10 +272,10 @@ const ScenarioGenerateDataForm = ({ form, visible }) => {
                   style={{
                     color: 'red',
                     marginLeft: 10,
-                    display: districtChecked ? 'none' : ''
+                    display: surroundingsChecked ? 'none' : ''
                   }}
                 >
-                  *Requires zone and district file.
+                  *Requires zone and surroundings file.
                 </small>
               </Row>
               <small>- Creates a fixed elevation terrain file.</small>
@@ -497,7 +499,7 @@ const ScenarioImportDataForm = ({ form, visible }) => {
       placeholder: 'Path to geometry of the zone',
       help: ''
     },
-    district: {
+    surroundings: {
       extension: ['.shp'],
       placeholder: 'Path to geometry of surroundings',
       help: ''

--- a/src/renderer/constants/inputEndpoints.json
+++ b/src/renderer/constants/inputEndpoints.json
@@ -1,6 +1,6 @@
 {
   "zone": "http://localhost:5050/api/inputs/building-properties/zone/geojson",
-  "district": "http://localhost:5050/api/inputs/building-properties/district/geojson",
+  "surroundings": "http://localhost:5050/api/inputs/building-properties/surroundings/geojson",
   "streets": "http://localhost:5050/api/inputs/others/streets/geojson",
   "dh": "http://localhost:5050/api/inputs/others/dh/geojson",
   "dc": "http://localhost:5050/api/inputs/others/dc/geojson"

--- a/src/renderer/reducers/inputEditor.js
+++ b/src/renderer/reducers/inputEditor.js
@@ -21,7 +21,7 @@ const initialState = {
   status: ''
 };
 
-const buildingGeometries = ['zone', 'district'];
+const buildingGeometries = ['zone', 'surroundings'];
 
 function createNestedProp(obj, prop, ...rest) {
   if (typeof obj[prop] == 'undefined') {
@@ -103,7 +103,7 @@ function deleteBuildings(state, buildings) {
   const isZoneBuilding = !!tables.zone[buildings[0]];
 
   // Track delete changes
-  const layer = isZoneBuilding ? 'zone' : 'district';
+  const layer = isZoneBuilding ? 'zone' : 'surroundings';
   changes.delete[layer] = changes.delete[layer] || [];
   changes.delete[layer].push(...buildings);
 
@@ -116,9 +116,9 @@ function deleteBuildings(state, buildings) {
     }
 
     if (isZoneBuilding) {
-      // Delete building from every table that is not district
+      // Delete building from every table that is not surroundings
       for (const table in tables) {
-        if (table != 'district') {
+        if (table != 'surroundings') {
           delete tables[table][building];
           tables = { ...tables, [table]: { ...tables[table] } };
         }
@@ -126,8 +126,8 @@ function deleteBuildings(state, buildings) {
       // Delete building from zone geojson
       geojsons = deleteGeoJsonFeature(geojsons, 'zone', building);
     } else {
-      delete tables.district[building];
-      geojsons = deleteGeoJsonFeature(geojsons, 'district', building);
+      delete tables.surroundings[building];
+      geojsons = deleteGeoJsonFeature(geojsons, 'surroundings', building);
     }
   }
   return { geojsons, tables, changes };


### PR DESCRIPTION
This PR goes hand-in-hand with the DatabaseFIX PR in CEA: https://github.com/architecture-building-systems/CityEnergyAnalyst/pull/2439

It includes updates to the interface to reflect the change of naming from district to surroundings for the buildings outside of the zone.

To test, replace the subfolder [win-unpacked](https://www.dropbox.com/s/hatb0p1i6ym0zks/win-unpacked.zip?dl=0) and start the GUI with the DatabaseFix branch in the CityEnergyAnalyst Repository.
