### PR TITLE
React input editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "antd": "^3.21.3",
     "axios": "^0.19.0",
     "babel-plugin-import": "^1.12.0",
+    "color-interpolate": "^1.0.5",
     "connected-react-router": "^6.5.2",
     "deck.gl": "^7.2.2",
     "electron-updater": "^4.1.2",

--- a/src/renderer/actions/inputEditor.js
+++ b/src/renderer/actions/inputEditor.js
@@ -40,13 +40,13 @@ export const fetchInputData = () =>
 export const saveChanges = () => (dispatch, getState) =>
   // eslint-disable-next-line no-undef
   new Promise((resolve, reject) => {
-    const { tables, geojsons, crs } = getState().inputData;
+    const { tables, geojsons, crs, schedules } = getState().inputData;
     dispatch(
       httpAction({
         url: '/inputs/all-inputs',
         method: 'PUT',
         type: SAVE_INPUTDATA,
-        data: { tables, geojsons, crs },
+        data: { tables, geojsons, crs, schedules },
         onSuccess: data => resolve(data),
         onFailure: error => reject(error)
       })
@@ -97,18 +97,25 @@ export const fetchBuildingSchedule = (buildings, fetchAll = false) => (
   return Promise.resolve();
 };
 
-export const discardChanges = () => dispatch =>
+export const discardChanges = () => (dispatch, getState) =>
   // eslint-disable-next-line no-undef
-  new Promise((resolve, reject) => {
-    dispatch(
-      httpAction({
-        url: '/inputs/all-inputs',
-        type: DISCARD_INPUTDATA_CHANGES,
-        onSuccess: data => resolve(data),
-        onFailure: error => reject(error)
-      })
-    );
-  });
+  Promise.all([
+    // eslint-disable-next-line no-undef
+    new Promise((resolve, reject) => {
+      dispatch(
+        httpAction({
+          url: '/inputs/all-inputs',
+          type: DISCARD_INPUTDATA_CHANGES,
+          onSuccess: data => resolve(data),
+          onFailure: error => reject(error)
+        })
+      );
+    }),
+    fetchBuildingSchedule(Object.keys(getState().inputData.schedules), true)(
+      dispatch,
+      getState
+    )
+  ]);
 
 export const updateInputData = (
   table = '',

--- a/src/renderer/actions/inputEditor.js
+++ b/src/renderer/actions/inputEditor.js
@@ -53,14 +53,20 @@ export const saveChanges = () => (dispatch, getState) =>
     );
   });
 
-export const fetchBuildingSchedule = buildings => (dispatch, getState) => {
-  const toFetch = buildings.filter(
-    building => !Object.keys(getState().inputData.schedules).includes(building)
-  );
+export const fetchBuildingSchedule = (buildings, fetchAll = false) => (
+  dispatch,
+  getState
+) => {
+  const toFetch = fetchAll
+    ? buildings
+    : buildings.filter(
+        building =>
+          !Object.keys(getState().inputData.schedules).includes(building)
+      );
   if (toFetch.length) {
     dispatch({ type: REQUEST_BUILDINGSCHEDULE });
     let errors = {};
-    const promises = buildings.map(building =>
+    const promises = toFetch.map(building =>
       axios
         .get(`http://localhost:5050/api/inputs/building-schedule/${building}`)
         .then(resp => {

--- a/src/renderer/actions/inputEditor.js
+++ b/src/renderer/actions/inputEditor.js
@@ -53,48 +53,35 @@ export const saveChanges = () => (dispatch, getState) =>
     );
   });
 
-export const fetchBuildingSchedule = (buildings, fetchAll = false) => (
-  dispatch,
-  getState
-) => {
-  const toFetch = fetchAll
-    ? buildings
-    : buildings.filter(
-        building =>
-          !Object.keys(getState().inputData.schedules).includes(building)
-      );
-  if (toFetch.length) {
-    dispatch({ type: REQUEST_BUILDINGSCHEDULE });
-    let errors = {};
-    const promises = toFetch.map(building =>
-      axios
-        .get(`http://localhost:5050/api/inputs/building-schedule/${building}`)
-        .then(resp => {
-          return { [building]: resp.data };
-        })
-        .catch(error => {
-          errors[building] = error.response.data;
-        })
-    );
-    // eslint-disable-next-line no-undef
-    return Promise.all(promises).then(values => {
-      if (Object.keys(errors).length) {
-        throw errors;
-      } else {
-        let out = {};
-        for (const schedule of values) {
-          const building = Object.keys(schedule)[0];
-          out[building] = schedule[building];
-        }
-        dispatch({
-          type: REQUEST_BUILDINGSCHEDULE_SUCCESS,
-          payload: out
-        });
-      }
-    });
-  }
+export const fetchBuildingSchedule = buildings => dispatch => {
+  dispatch({ type: REQUEST_BUILDINGSCHEDULE });
+  let errors = {};
+  const promises = buildings.map(building =>
+    axios
+      .get(`http://localhost:5050/api/inputs/building-schedule/${building}`)
+      .then(resp => {
+        return { [building]: resp.data };
+      })
+      .catch(error => {
+        errors[building] = error.response.data;
+      })
+  );
   // eslint-disable-next-line no-undef
-  return Promise.resolve();
+  return Promise.all(promises).then(values => {
+    if (Object.keys(errors).length) {
+      throw errors;
+    } else {
+      let out = {};
+      for (const schedule of values) {
+        const building = Object.keys(schedule)[0];
+        out[building] = schedule[building];
+      }
+      dispatch({
+        type: REQUEST_BUILDINGSCHEDULE_SUCCESS,
+        payload: out
+      });
+    }
+  });
 };
 
 export const discardChanges = () => (dispatch, getState) =>
@@ -111,7 +98,7 @@ export const discardChanges = () => (dispatch, getState) =>
         })
       );
     }),
-    fetchBuildingSchedule(Object.keys(getState().inputData.schedules), true)(
+    fetchBuildingSchedule(Object.keys(getState().inputData.schedules))(
       dispatch,
       getState
     )

--- a/src/renderer/actions/inputEditor.js
+++ b/src/renderer/actions/inputEditor.js
@@ -15,6 +15,8 @@ export const REQUEST_MAPDATA = 'REQUEST_MAPDATA';
 export const RECEIVE_MAPDATA = 'RECEIVE_MAPDATA';
 export const SET_SELECTED = 'SET_SELECTED';
 export const UPDATE_INPUTDATA = 'UPDATE_INPUTDATA';
+export const UPDATE_YEARSCHEDULE = 'UPDATE_YEARSCHEDULE';
+export const UPDATE_DAYSCHEDULE = 'UPDATE_DAYSCHEDULE';
 export const DELETE_BUILDINGS = 'DELETE_BUILDINGS';
 export const SAVE_INPUTDATA = 'SAVE_INPUTDATA';
 export const SAVE_INPUTDATA_SUCCESS = 'SAVE_INPUTDATA_SUCCESS';
@@ -109,6 +111,22 @@ export const updateInputData = (
 ) => ({
   type: UPDATE_INPUTDATA,
   payload: { table, buildings, properties }
+});
+
+export const updateYearSchedule = (buildings = [], month = '', value = 0) => ({
+  type: UPDATE_YEARSCHEDULE,
+  payload: { buildings, month, value }
+});
+
+export const updateDaySchedule = (
+  buildings = [],
+  tab = '',
+  day = '',
+  hour = 0,
+  value = ''
+) => ({
+  type: UPDATE_DAYSCHEDULE,
+  payload: { buildings, tab, day, hour, value }
 });
 
 export const deleteBuildings = (buildings = []) => ({

--- a/src/renderer/components/InputEditor/InputEditor.js
+++ b/src/renderer/components/InputEditor/InputEditor.js
@@ -8,7 +8,6 @@ import CenterSpinner from '../HomePage/CenterSpinner';
 import NavigationPrompt from './NavigationPrompt';
 import { withErrorBoundary } from '../../utils/ErrorBoundary';
 import './InputEditor.css';
-import ScheduleEditor from './ScheduleEditor';
 
 const MAP_STYLE = {
   height: '500px',
@@ -78,7 +77,7 @@ const InputTable = () => {
         {TabPanes}
       </Tabs>
       <div className="cea-input-editor-table">
-        {tab != 'schedules' ? <Table tab={tab} /> : <ScheduleEditor />}
+        <Table tab={tab} />
       </div>
     </div>
   );

--- a/src/renderer/components/InputEditor/ScheduleEditor.css
+++ b/src/renderer/components/InputEditor/ScheduleEditor.css
@@ -40,6 +40,14 @@
 .cea-schedule-no-data {
   grid-column: 1/-1;
   grid-row: 1/-1;
+  margin: auto;
+}
+
+.cea-schedule-error {
+  grid-column: 1/-1;
+  grid-row: 1/-1;
+  overflow: auto;
+  text-align: center;
   height: 100%;
   width: 100%;
 }

--- a/src/renderer/components/InputEditor/ScheduleEditor.js
+++ b/src/renderer/components/InputEditor/ScheduleEditor.js
@@ -56,6 +56,7 @@ const ScheduleEditor = ({ selected, schedules, tabulator }) => {
       tabulator.current.replaceData(
         buildings.sort().map(building => ({ Name: building }))
       );
+    tabulator.current.selectRow(selected);
     tabulator.current.redraw();
   }, [tables]);
 
@@ -156,6 +157,9 @@ const DataTable = ({ selected, tab, schedules }) => {
           }
         }))
       ],
+      validationFailed: cell => {
+        cell.cancelEdit();
+      },
       cellEdited: cell => {
         formatCellStyle(cell);
         dispatch(
@@ -205,7 +209,6 @@ const YearTable = ({ selected, schedules }) => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    console.log('render year');
     tabulator.current = new Tabulator(divRef.current, {
       data: [],
       index: 'name',
@@ -216,6 +219,7 @@ const YearTable = ({ selected, schedules }) => {
           field: i.toString(),
           headerSort: false,
           editor: 'input',
+          validator: ['max:1', 'min:0'],
           // Hack to allow editing when double clicking
           cellDblClick: () => {},
           formatter: cell => {
@@ -224,6 +228,9 @@ const YearTable = ({ selected, schedules }) => {
           }
         }))
       ],
+      validationFailed: cell => {
+        cell.cancelEdit();
+      },
       cellEdited: cell => {
         formatCellStyle(cell);
         dispatch(

--- a/src/renderer/components/InputEditor/ScheduleEditor.js
+++ b/src/renderer/components/InputEditor/ScheduleEditor.js
@@ -199,6 +199,10 @@ const DataTable = ({ selected, tab, schedules }) => {
       tabulator.current.updateOrAddData(parseData(schedules, selected, tab));
   }, [selected, schedules, tab]);
 
+  useEffect(() => {
+    tabulator.current.redraw(true);
+  }, [selected, tab]);
+
   return <div ref={divRef} />;
 };
 

--- a/src/renderer/components/InputEditor/ScheduleEditor.js
+++ b/src/renderer/components/InputEditor/ScheduleEditor.js
@@ -20,6 +20,7 @@ const ScheduleEditor = ({ selected, schedules, tabulator }) => {
   const buildings = Object.keys(tables.zone || {});
   const dispatch = useDispatch();
   const divRef = useRef(null);
+  const timeoutRef = useRef();
 
   const selectRow = (e, cell) => {
     const row = cell.getRow();
@@ -64,15 +65,23 @@ const ScheduleEditor = ({ selected, schedules, tabulator }) => {
     tabulator.current && tabulator.current.deselectRow();
     if (buildings.includes(selected[0])) {
       tabulator.current && tabulator.current.selectRow(selected);
-      setLoading(true);
-      dispatch(fetchBuildingSchedule(selected))
-        .catch(error => {
-          console.log(error);
-          setErrors(error);
-        })
-        .finally(() => {
-          setLoading(false);
-        });
+      const missingSchedules = selected.filter(
+        building => !Object.keys(schedules).includes(building)
+      );
+      if (missingSchedules.length) {
+        setLoading(true);
+        clearTimeout(timeoutRef.current);
+        timeoutRef.current = setTimeout(() => {
+          dispatch(fetchBuildingSchedule(missingSchedules))
+            .catch(error => {
+              console.log(error);
+              setErrors(error);
+            })
+            .finally(() => {
+              setLoading(false);
+            });
+        }, 1000);
+      }
     }
     tabulator.current &&
       tabulator.current.getFilters().length &&

--- a/src/renderer/components/InputEditor/ScheduleEditor.js
+++ b/src/renderer/components/InputEditor/ScheduleEditor.js
@@ -192,7 +192,7 @@ const DataTable = ({ selected, tab, schedules }) => {
       tab &&
       selected.length &&
       selected.every(building => Object.keys(schedules).includes(building)) &&
-      tabulator.current.setData(parseData(schedules, selected, tab));
+      tabulator.current.updateOrAddData(parseData(schedules, selected, tab));
   }, [selected, schedules, tab]);
 
   return <div ref={divRef} />;
@@ -265,7 +265,7 @@ const YearTable = ({ selected, schedules }) => {
     tabulator.current &&
       selected.length &&
       selected.every(building => Object.keys(schedules).includes(building)) &&
-      tabulator.current.setData(parseYearData(schedules, selected));
+      tabulator.current.updateOrAddData(parseYearData(schedules, selected));
   }, [schedules, selected]);
 
   return <div ref={divRef} />;
@@ -304,7 +304,6 @@ const parseYearData = (schedules, selected) => {
     const buildingSchedule = schedules[building].MONTHLY_MULTIPLIER;
     out = diffArray(out, buildingSchedule);
   }
-  console.log(out);
   return [{ name: 'MONTHLY_MULTIPLIER', ...out }];
 };
 
@@ -316,7 +315,6 @@ const parseData = (schedules, selected, tab) => {
       out[day] = diffArray(out[day], days[day]);
     }
   }
-  console.log(out);
   return Object.keys(out).map(day => ({ DAY: day, ...out[day] }));
 };
 

--- a/src/renderer/components/InputEditor/ScheduleEditor.js
+++ b/src/renderer/components/InputEditor/ScheduleEditor.js
@@ -72,6 +72,8 @@ const ScheduleEditor = ({ selected, schedules, tabulator }) => {
     tabulator.current && tabulator.current.deselectRow();
     if (buildings.includes(selected[0])) {
       tabulator.current && tabulator.current.selectRow(selected);
+      setLoading(false);
+      clearTimeout(timeoutRef.current);
       const missingSchedules = selected.filter(
         building => !Object.keys(schedules).includes(building)
       );
@@ -87,9 +89,6 @@ const ScheduleEditor = ({ selected, schedules, tabulator }) => {
               setLoading(false);
             });
         }, 1000);
-      } else {
-        clearTimeout(timeoutRef.current);
-        setLoading(false);
       }
     }
     tabulator.current &&

--- a/src/renderer/components/InputEditor/ScheduleEditor.js
+++ b/src/renderer/components/InputEditor/ScheduleEditor.js
@@ -24,16 +24,20 @@ const ScheduleEditor = ({ selected, schedules, tabulator }) => {
 
   const selectRow = (e, cell) => {
     const row = cell.getRow();
-    const selectedRows = cell
-      .getTable()
-      .getSelectedData()
-      .map(data => data.Name);
-    if (cell.getRow().isSelected()) {
-      dispatch(
-        setSelected(selectedRows.filter(name => name !== row.getIndex()))
-      );
+    if (!e.ctrlKey) {
+      dispatch(setSelected([row.getIndex()]));
     } else {
-      dispatch(setSelected([...selectedRows, row.getIndex()]));
+      const selectedRows = cell
+        .getTable()
+        .getSelectedData()
+        .map(data => data.Name);
+      if (cell.getRow().isSelected()) {
+        dispatch(
+          setSelected(selectedRows.filter(name => name !== row.getIndex()))
+        );
+      } else {
+        dispatch(setSelected([...selectedRows, row.getIndex()]));
+      }
     }
   };
 
@@ -70,7 +74,6 @@ const ScheduleEditor = ({ selected, schedules, tabulator }) => {
       );
       if (missingSchedules.length) {
         setLoading(true);
-        clearTimeout(timeoutRef.current);
         timeoutRef.current = setTimeout(() => {
           dispatch(fetchBuildingSchedule(missingSchedules))
             .catch(error => {
@@ -81,6 +84,9 @@ const ScheduleEditor = ({ selected, schedules, tabulator }) => {
               setLoading(false);
             });
         }, 1000);
+      } else {
+        clearTimeout(timeoutRef.current);
+        setLoading(false);
       }
     }
     tabulator.current &&

--- a/src/renderer/components/InputEditor/ScheduleEditor.js
+++ b/src/renderer/components/InputEditor/ScheduleEditor.js
@@ -145,7 +145,7 @@ const DataTable = ({ selected, tab, schedules }) => {
       columns: [
         { title: 'DAY \\ HOUR', field: 'DAY', width: 100, headerSort: false },
         ...[...Array(24).keys()].map(i => ({
-          title: i.toString(),
+          title: (i + 1).toString(),
           field: i.toString(),
           headerSort: false,
           editor: 'input',

--- a/src/renderer/components/InputEditor/ScheduleEditor.js
+++ b/src/renderer/components/InputEditor/ScheduleEditor.js
@@ -4,9 +4,8 @@ import { fetchBuildingSchedule, setSelected } from '../../actions/inputEditor';
 import Tabulator from 'tabulator-tables';
 import 'tabulator-tables/dist/css/tabulator.min.css';
 import './ScheduleEditor.css';
-import CenterSpinner from '../HomePage/CenterSpinner';
 import { months_short } from '../../constants/months';
-import { Tabs, Spin, Modal, Button, Card } from 'antd';
+import { Tabs, Spin, Button, Card } from 'antd';
 
 const ScheduleEditor = () => {
   const { selected, tables } = useSelector(state => state.inputData);
@@ -33,6 +32,7 @@ const ScheduleEditor = () => {
     }
   };
 
+  // Initialize table
   useEffect(() => {
     tabulator.current = new Tabulator(divRef.current, {
       data: buildings.map(building => ({ Name: building })),
@@ -83,10 +83,7 @@ const ScheduleEditor = () => {
           <div className="cea-schedule-test">
             {buildings.includes(selected[0]) ? (
               Object.keys(errors).length ? (
-                <div
-                  className="cea-schedule-no-data"
-                  style={{ overflow: 'auto' }}
-                >
+                <div className="cea-schedule-error">
                   ERRORS FOUND:
                   {Object.keys(errors).map(building => (
                     <div

--- a/src/renderer/components/InputEditor/ScheduleEditor.js
+++ b/src/renderer/components/InputEditor/ScheduleEditor.js
@@ -101,13 +101,18 @@ const ScheduleEditor = ({ selected, schedules, tabulator }) => {
             ) : (
               <React.Fragment>
                 <div className="cea-schedule-year">
-                  <YearTable selected={selected} schedules={schedules} />
+                  <YearTable
+                    selected={selected}
+                    schedules={schedules}
+                    loading={loading}
+                  />
                 </div>
                 <div className="cea-schedule-data">
                   <DataTable
                     selected={selected}
                     tab={tab}
                     schedules={schedules}
+                    loading={loading}
                   />
                 </div>
                 <div className="cea-schedule-tabs">
@@ -132,7 +137,7 @@ const ScheduleEditor = ({ selected, schedules, tabulator }) => {
   );
 };
 
-const DataTable = ({ selected, tab, schedules }) => {
+const DataTable = ({ selected, tab, schedules, loading }) => {
   const tabulator = useRef(null);
   const divRef = useRef(null);
   const tooltipsRef = useRef({ selected, schedules, tab });
@@ -192,21 +197,20 @@ const DataTable = ({ selected, tab, schedules }) => {
 
   useEffect(() => {
     tooltipsRef.current = { selected, schedules, tab };
-    tabulator.current &&
-      tab &&
-      selected.length &&
+    tab &&
       selected.every(building => Object.keys(schedules).includes(building)) &&
       tabulator.current.updateOrAddData(parseData(schedules, selected, tab));
   }, [selected, schedules, tab]);
 
   useEffect(() => {
-    tabulator.current.redraw(true);
-  }, [selected, tab]);
+    selected.every(building => Object.keys(schedules).includes(building)) &&
+      tabulator.current.redraw(true);
+  }, [selected, tab, loading]);
 
   return <div ref={divRef} />;
 };
 
-const YearTable = ({ selected, schedules }) => {
+const YearTable = ({ selected, schedules, loading }) => {
   const tabulator = useRef(null);
   const divRef = useRef(null);
   const tooltipsRef = useRef({ selected, schedules });
@@ -273,11 +277,14 @@ const YearTable = ({ selected, schedules }) => {
 
   useEffect(() => {
     tooltipsRef.current = { selected, schedules };
-    tabulator.current &&
-      selected.length &&
-      selected.every(building => Object.keys(schedules).includes(building)) &&
+    selected.every(building => Object.keys(schedules).includes(building)) &&
       tabulator.current.updateOrAddData(parseYearData(schedules, selected));
   }, [schedules, selected]);
+
+  useEffect(() => {
+    selected.every(building => Object.keys(schedules).includes(building)) &&
+      tabulator.current.redraw(true);
+  }, [selected, loading]);
 
   return <div ref={divRef} />;
 };

--- a/src/renderer/components/InputEditor/ScheduleEditor.js
+++ b/src/renderer/components/InputEditor/ScheduleEditor.js
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
+import interpolate from 'color-interpolate';
 import {
   fetchBuildingSchedule,
   setSelected,
@@ -11,6 +12,8 @@ import 'tabulator-tables/dist/css/tabulator.min.css';
 import './ScheduleEditor.css';
 import { months_short } from '../../constants/months';
 import { Tabs, Spin } from 'antd';
+
+const colormap = interpolate(['white', '#006ad5']);
 
 const ScheduleEditor = ({ selected, schedules, tabulator }) => {
   const { tables } = useSelector(state => state.inputData);
@@ -322,13 +325,31 @@ const ScheduleTab = ({ tab, setTab, schedules }) => {
 };
 
 const formatCellStyle = cell => {
-  if (cell.getValue() == 'DIFF') {
+  const states = ['OFF', 'SETBACK', 'SETPOINT'];
+  const value = cell.getValue();
+  if (value == 'DIFF') {
     cell.getElement().style.fontWeight = 'bold';
     cell.getElement().style.fontStyle = 'italic';
   } else {
+    if (!isNaN(value)) {
+      cell.getElement().style.backgroundColor = addRGBAlpha(
+        colormap(value),
+        0.5
+      );
+    } else if (states.includes(value)) {
+      cell.getElement().style.backgroundColor = addRGBAlpha(
+        colormap(states.indexOf(value) / (states.length - 1)),
+        0.5
+      );
+    }
     cell.getElement().style.fontWeight = 'normal';
     cell.getElement().style.fontStyle = 'normal';
   }
+};
+
+const addRGBAlpha = (color, opacity) => {
+  const rgb = color.replace(/[^\d,]/g, '').split(',');
+  return `rgba(${rgb[0]}, ${rgb[1]}, ${rgb[2]}, ${opacity}`;
 };
 
 const parseYearData = (schedules, selected) => {

--- a/src/renderer/components/InputEditor/ScheduleEditor.js
+++ b/src/renderer/components/InputEditor/ScheduleEditor.js
@@ -46,25 +46,22 @@ const ScheduleEditor = () => {
   }, []);
 
   useEffect(() => {
+    tabulator.current && tabulator.current.deselectRow();
     if (buildings.includes(selected[0])) {
-      if (tabulator.current) {
-        tabulator.current.deselectRow();
-        tabulator.current.selectRow(selected);
-        tabulator.current.getFilters().length &&
-          tabulator.current.setFilter('Name', 'in', selected);
-      }
-      if (selected.length) {
-        setLoading(true);
-        dispatch(fetchBuildingSchedule(selected))
-          .catch(error => {
-            console.log(error);
-            setErrors(error);
-          })
-          .finally(() => {
-            setLoading(false);
-          });
-      }
-    } else tabulator.current && tabulator.current.deselectRow();
+      tabulator.current && tabulator.current.selectRow(selected);
+      setLoading(true);
+      dispatch(fetchBuildingSchedule(selected))
+        .catch(error => {
+          console.log(error);
+          setErrors(error);
+        })
+        .finally(() => {
+          setLoading(false);
+        });
+    }
+    tabulator.current &&
+      tabulator.current.getFilters().length &&
+      tabulator.current.setFilter('Name', 'in', selected);
   }, [selected]);
 
   if (!buildings.length) return <div>No buildings found</div>;

--- a/src/renderer/components/InputEditor/ScheduleEditor.js
+++ b/src/renderer/components/InputEditor/ScheduleEditor.js
@@ -181,7 +181,7 @@ const DataTable = ({ selected, tab, schedules, loading }) => {
             tooltipsRef.current.selected,
             tooltipsRef.current.tab,
             cell.getData().DAY,
-            cell.getField(),
+            Number(cell.getField()),
             cell.getValue()
           )
         );

--- a/src/renderer/components/InputEditor/Table.js
+++ b/src/renderer/components/InputEditor/Table.js
@@ -223,6 +223,9 @@ const Table = ({ tab }) => {
         await dispatch(discardChanges())
           .then(data => {
             console.log(data);
+            message.config({
+              top: 120
+            });
             message.info('Unsaved changes have been discarded.');
           })
           .catch(error => {

--- a/src/renderer/components/InputEditor/Table.js
+++ b/src/renderer/components/InputEditor/Table.js
@@ -2,7 +2,7 @@ import React, { useEffect, useRef, useState } from 'react';
 import ReactDOM from 'react-dom';
 import { useSelector, useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { Card, Button, Modal, message, Tooltip } from 'antd';
+import { Card, Button, Modal, message, Tooltip, Icon } from 'antd';
 import {
   setSelected,
   updateInputData,
@@ -27,6 +27,14 @@ const Table = ({ tab }) => {
       <Card
         headStyle={{ backgroundColor: '#f1f1f1' }}
         size="small"
+        title={
+          <Tooltip
+            placement="right"
+            title="You can select multiple buildings in the table and the map by holding down the `Ctrl` key"
+          >
+            <Icon type="info-circle" />
+          </Tooltip>
+        }
         extra={
           <TableButtons selected={selected} tabulator={tabulator} tab={tab} />
         }

--- a/src/renderer/components/InputEditor/Table.js
+++ b/src/renderer/components/InputEditor/Table.js
@@ -391,16 +391,20 @@ const useTableData = tab => {
 
   const selectRow = (e, cell) => {
     const row = cell.getRow();
-    const selectedRows = cell
-      .getTable()
-      .getSelectedData()
-      .map(data => data.Name);
-    if (cell.getRow().isSelected()) {
-      dispatch(
-        setSelected(selectedRows.filter(name => name !== row.getIndex()))
-      );
+    if (!e.ctrlKey) {
+      dispatch(setSelected([row.getIndex()]));
     } else {
-      dispatch(setSelected([...selectedRows, row.getIndex()]));
+      const selectedRows = cell
+        .getTable()
+        .getSelectedData()
+        .map(data => data.Name);
+      if (cell.getRow().isSelected()) {
+        dispatch(
+          setSelected(selectedRows.filter(name => name !== row.getIndex()))
+        );
+      } else {
+        dispatch(setSelected([...selectedRows, row.getIndex()]));
+      }
     }
   };
 

--- a/src/renderer/components/InputEditor/Table.js
+++ b/src/renderer/components/InputEditor/Table.js
@@ -347,7 +347,9 @@ const TableEditor = ({ tab, selected, tabulator }) => {
               col
             );
           });
-      } else tabulator.current.replaceData(data);
+      } else if (tabulator.current.getData().length == data.length) {
+        tabulator.current.updateData(data);
+      } else tabulator.current.setData(data);
     }
   }, [data]);
 

--- a/src/renderer/components/InputEditor/Table.js
+++ b/src/renderer/components/InputEditor/Table.js
@@ -167,7 +167,7 @@ const ChangesSummary = ({ changes }) => {
                     property => (
                       <div key={property}>
                         <i>{property}</i>
-                        {`: ${changes.update[table][building][property].oldValue}
+                        {` : ${changes.update[table][building][property].oldValue}
                         → 
                         ${changes.update[table][building][property].newValue}`}
                       </div>

--- a/src/renderer/components/InputEditor/Table.js
+++ b/src/renderer/components/InputEditor/Table.js
@@ -14,164 +14,42 @@ import EditSelectedModal from './EditSelectedModal';
 import routes from '../../constants/routes';
 import Tabulator from 'tabulator-tables';
 import 'tabulator-tables/dist/css/tabulator.min.css';
-
-const useTableData = tab => {
-  const tables = useSelector(state => state.inputData.tables);
-  const columns = useSelector(state => state.inputData.columns);
-
-  const [data, setData] = useState([]);
-  const [columnDef, setColumnDef] = useState({ columns: [], description: [] });
-
-  const dispatch = useDispatch();
-
-  const selectRow = (e, cell) => {
-    const row = cell.getRow();
-    const selectedRows = cell
-      .getTable()
-      .getSelectedData()
-      .map(data => data.Name);
-    if (cell.getRow().isSelected()) {
-      dispatch(
-        setSelected(selectedRows.filter(name => name !== row.getIndex()))
-      );
-    } else {
-      dispatch(setSelected([...selectedRows, row.getIndex()]));
-    }
-  };
-
-  const getData = () =>
-    Object.keys(tables[tab])
-      .sort((a, b) => (a > b ? 1 : -1))
-      .map(row => ({
-        Name: row,
-        ...tables[tab][row]
-      }));
-
-  const getColumnDef = () => {
-    let description = [];
-    let _columns = Object.keys(columns[tab]).map(column => {
-      description.push({
-        description: columns[tab][column].description,
-        unit: columns[tab][column].unit
-      });
-      let columnDef = { title: column, field: column };
-      if (column === 'Name') {
-        columnDef.frozen = true;
-        columnDef.cellClick = selectRow;
-      } else if (column !== 'REFERENCE') {
-        columnDef.editor = 'input';
-        columnDef.validator =
-          columns[tab][column].type === 'str' ? 'string' : 'numeric';
-        columnDef.minWidth = 100;
-        // Hack to allow editing when double clicking
-        columnDef.cellDblClick = () => {};
-      }
-      return columnDef;
-    });
-    return { columns: _columns, description: description };
-  };
-  useEffect(() => {
-    setColumnDef(getColumnDef());
-    setData(getData());
-  }, [tab]);
-
-  useEffect(() => {
-    setData(getData());
-  }, [tables[tab]]);
-
-  return [data, columnDef];
-};
+import ScheduleEditor from './ScheduleEditor';
 
 const Table = ({ tab }) => {
-  const [data, columnDef] = useTableData(tab);
-  const { selected, changes } = useSelector(state => state.inputData);
+  const { selected, changes, schedules } = useSelector(
+    state => state.inputData
+  );
+  const tabulator = useRef(null);
+
+  return (
+    <React.Fragment>
+      <Card
+        headStyle={{ backgroundColor: '#f1f1f1' }}
+        size="small"
+        extra={
+          <TableButtons selected={selected} tabulator={tabulator} tab={tab} />
+        }
+      >
+        {tab == 'schedules' ? (
+          <ScheduleEditor
+            tabulator={tabulator}
+            selected={selected}
+            schedules={schedules}
+          />
+        ) : (
+          <TableEditor tabulator={tabulator} tab={tab} selected={selected} />
+        )}
+      </Card>
+      <InputEditorButtons changes={changes} />
+    </React.Fragment>
+  );
+};
+
+const InputEditorButtons = ({ changes }) => {
+  const dispatch = useDispatch();
   const noChanges =
     !Object.keys(changes.update).length && !Object.keys(changes.delete).length;
-  const dispatch = useDispatch();
-  const tableRef = useRef(tab);
-  const tabulator = useRef(null);
-  const divRef = useRef(null);
-
-  useEffect(() => {
-    tabulator.current = new Tabulator(divRef.current, {
-      data: data,
-      index: 'Name',
-      columns: columnDef.columns,
-      layout: 'fitDataFill',
-      height: '300px',
-      validationFailed: cell => {
-        cell.cancelEdit();
-      },
-      cellEdited: cell => {
-        dispatch(
-          updateInputData(
-            tableRef.current,
-            [cell.getData()['Name']],
-            [{ property: cell.getField(), value: cell.getValue() }]
-          )
-        );
-      },
-      placeholder: '<div>No matching records found.</div>'
-    });
-  }, []);
-
-  // Keep reference of current table name
-  useEffect(() => {
-    tableRef.current = tab;
-  }, [tab]);
-
-  useEffect(() => {
-    if (tabulator.current) {
-      tabulator.current.setData([]);
-      tabulator.current.setColumns(columnDef.columns);
-    }
-  }, [columnDef]);
-
-  useEffect(() => {
-    if (tabulator.current) {
-      if (!tabulator.current.getData().length) {
-        tabulator.current.setData(data);
-        tabulator.current.selectRow(selected);
-        // Add tooltips to column headers on new data
-        document
-          .querySelectorAll('.tabulator-col-content')
-          .forEach((col, index) => {
-            const { description, unit } = columnDef.description[index];
-            ReactDOM.render(
-              <Tooltip
-                title={
-                  description && (
-                    <div>
-                      {description}
-                      <br />
-                      {unit}
-                    </div>
-                  )
-                }
-                getPopupContainer={() => {
-                  return document.getElementsByClassName('ant-card-body')[0];
-                }}
-              >
-                <div className="tabulator-col-title">
-                  {columnDef.columns[index].title}
-                </div>
-                <div className="tabulator-arrow"></div>
-              </Tooltip>,
-              col
-            );
-          });
-      } else tabulator.current.updateData(data);
-    }
-  }, [data]);
-
-  useEffect(() => {
-    if (tabulator.current) {
-      tabulator.current.deselectRow();
-      tabulator.current.selectRow(selected);
-      tabulator.current.getFilters().length &&
-        tabulator.current.setFilter('Name', 'in', selected);
-    }
-  }, [selected]);
 
   const _saveChanges = () => {
     Modal.confirm({
@@ -238,28 +116,6 @@ const Table = ({ tab }) => {
 
   return (
     <React.Fragment>
-      <Card
-        headStyle={{ backgroundColor: '#f1f1f1' }}
-        size="small"
-        extra={
-          <TableButtons selected={selected} tabulator={tabulator} table={tab} />
-        }
-      >
-        <div ref={divRef} style={{ display: data.length ? 'block' : 'none' }} />
-        {!data.length ? (
-          <div>
-            Input file could not be found. You can create the file using
-            {tab == 'surroundings' ? (
-              <Link to={`${routes.TOOLS}/surroundings-helper`}>
-                {' surroundings-helper '}
-              </Link>
-            ) : (
-              <Link to={`${routes.TOOLS}/data-helper`}>{' data-helper '}</Link>
-            )}
-            tool.
-          </div>
-        ) : null}
-      </Card>
       <Button style={{ margin: 5 }} disabled={noChanges} onClick={_saveChanges}>
         Save
       </Button>
@@ -328,7 +184,7 @@ const ChangesSummary = ({ changes }) => {
   );
 };
 
-const TableButtons = ({ selected, tabulator, table }) => {
+const TableButtons = ({ selected, tabulator, tab }) => {
   const [filterToggle, setFilterToggle] = useState(false);
   const [selectedInTable, setSelectedInTable] = useState(true);
   const [modalVisible, setModalVisible] = useState(false);
@@ -336,9 +192,9 @@ const TableButtons = ({ selected, tabulator, table }) => {
   const dispatch = useDispatch();
 
   useEffect(() => {
-    const tableData = data[table] || {};
+    const tableData = data[tab] || tab == 'schedules' ? data['zone'] : {};
     setSelectedInTable(Object.keys(tableData).includes(selected[0]));
-  }, [table, selected]);
+  }, [tab, selected]);
 
   const selectAll = () => {
     dispatch(setSelected(tabulator.current.getData().map(data => data.Name)));
@@ -350,6 +206,7 @@ const TableButtons = ({ selected, tabulator, table }) => {
     } else {
       tabulator.current.setFilter('Name', 'in', selected);
     }
+    tabulator.current.redraw();
     setFilterToggle(oldValue => !oldValue);
   };
 
@@ -395,7 +252,9 @@ const TableButtons = ({ selected, tabulator, table }) => {
       </Button>
       {selectedInTable ? (
         <React.Fragment>
-          <Button onClick={editSelected}>Edit Selection</Button>
+          {tab != 'schedules' && (
+            <Button onClick={editSelected}>Edit Selection</Button>
+          )}
           <Button onClick={clearSelected}>Clear Selection</Button>
           <Button type="danger" onClick={deleteSelected}>
             Delete Selection
@@ -406,10 +265,184 @@ const TableButtons = ({ selected, tabulator, table }) => {
         visible={modalVisible}
         setVisible={setModalVisible}
         inputTable={tabulator.current}
-        table={table}
+        table={tab}
       />
     </div>
   );
+};
+
+const TableEditor = ({ tab, selected, tabulator }) => {
+  const [data, columnDef] = useTableData(tab);
+  const dispatch = useDispatch();
+  const divRef = useRef(null);
+  const tableRef = useRef(tab);
+
+  useEffect(() => {
+    const filtered = tabulator.current && tabulator.current.getFilters().length;
+    tabulator.current = new Tabulator(divRef.current, {
+      data: data,
+      index: 'Name',
+      columns: columnDef.columns,
+      layout: 'fitDataFill',
+      height: '300px',
+      validationFailed: cell => {
+        cell.cancelEdit();
+      },
+      cellEdited: cell => {
+        dispatch(
+          updateInputData(
+            tableRef.current,
+            [cell.getData()['Name']],
+            [{ property: cell.getField(), value: cell.getValue() }]
+          )
+        );
+      },
+      placeholder: '<div>No matching records found.</div>'
+    });
+    filtered && tabulator.current.setFilter('Name', 'in', selected);
+  }, []);
+
+  // Keep reference of current table name
+  useEffect(() => {
+    tableRef.current = tab;
+  }, [tab]);
+
+  useEffect(() => {
+    if (tabulator.current) {
+      tabulator.current.setData([]);
+      tabulator.current.setColumns(columnDef.columns);
+    }
+  }, [columnDef]);
+
+  useEffect(() => {
+    if (tabulator.current) {
+      if (!tabulator.current.getData().length) {
+        tabulator.current.setData(data);
+        tabulator.current.selectRow(selected);
+        // Add tooltips to column headers on new data
+        document
+          .querySelectorAll('.tabulator-col-content')
+          .forEach((col, index) => {
+            const { description, unit } = columnDef.description[index];
+            ReactDOM.render(
+              <Tooltip
+                title={
+                  description && (
+                    <div>
+                      {description}
+                      <br />
+                      {unit}
+                    </div>
+                  )
+                }
+                getPopupContainer={() => {
+                  return document.getElementsByClassName('ant-card-body')[0];
+                }}
+              >
+                <div className="tabulator-col-title">
+                  {columnDef.columns[index].title}
+                </div>
+                <div className="tabulator-arrow"></div>
+              </Tooltip>,
+              col
+            );
+          });
+      } else tabulator.current.replaceData(data);
+    }
+  }, [data]);
+
+  useEffect(() => {
+    if (tabulator.current) {
+      tabulator.current.deselectRow();
+      tabulator.current.selectRow(selected);
+      tabulator.current.getFilters().length &&
+        tabulator.current.setFilter('Name', 'in', selected);
+    }
+  }, [selected]);
+
+  return (
+    <React.Fragment>
+      <div ref={divRef} style={{ display: data.length ? 'block' : 'none' }} />
+      {!data.length ? (
+        <div>
+          Input file could not be found. You can create the file using
+          {tab == 'surroundings' ? (
+            <Link to={`${routes.TOOLS}/surroundings-helper`}>
+              {' surroundings-helper '}
+            </Link>
+          ) : (
+            <Link to={`${routes.TOOLS}/data-helper`}>{' data-helper '}</Link>
+          )}
+          tool.
+        </div>
+      ) : null}
+    </React.Fragment>
+  );
+};
+
+const useTableData = tab => {
+  const { columns, tables } = useSelector(state => state.inputData);
+  const [data, setData] = useState([]);
+  const [columnDef, setColumnDef] = useState({ columns: [], description: [] });
+
+  const dispatch = useDispatch();
+
+  const selectRow = (e, cell) => {
+    const row = cell.getRow();
+    const selectedRows = cell
+      .getTable()
+      .getSelectedData()
+      .map(data => data.Name);
+    if (cell.getRow().isSelected()) {
+      dispatch(
+        setSelected(selectedRows.filter(name => name !== row.getIndex()))
+      );
+    } else {
+      dispatch(setSelected([...selectedRows, row.getIndex()]));
+    }
+  };
+
+  const getData = () =>
+    Object.keys(tables[tab])
+      .sort()
+      .map(row => ({
+        Name: row,
+        ...tables[tab][row]
+      }));
+
+  const getColumnDef = () => {
+    let description = [];
+    let _columns = Object.keys(columns[tab]).map(column => {
+      description.push({
+        description: columns[tab][column].description,
+        unit: columns[tab][column].unit
+      });
+      let columnDef = { title: column, field: column };
+      if (column === 'Name') {
+        columnDef.frozen = true;
+        columnDef.cellClick = selectRow;
+      } else if (column !== 'REFERENCE') {
+        columnDef.editor = 'input';
+        columnDef.validator =
+          columns[tab][column].type === 'str' ? 'string' : 'numeric';
+        columnDef.minWidth = 100;
+        // Hack to allow editing when double clicking
+        columnDef.cellDblClick = () => {};
+      }
+      return columnDef;
+    });
+    return { columns: _columns, description: description };
+  };
+  useEffect(() => {
+    setColumnDef(getColumnDef());
+    setData(getData());
+  }, [tab]);
+
+  useEffect(() => {
+    setData(getData());
+  }, [tables[tab]]);
+
+  return [data, columnDef];
 };
 
 export default Table;

--- a/src/renderer/components/Map/Map.js
+++ b/src/renderer/components/Map/Map.js
@@ -409,16 +409,19 @@ function updateTooltip({ x, y, object, layer }) {
     let innerHTML = '';
 
     if (layer.id === 'zone' || layer.id === 'surroundings') {
-      Object.keys(properties).forEach(key => {
-        innerHTML += `<div><b>${key}</b>: ${properties[key]}</div>`;
-      });
-      let area = calcArea(object);
-      innerHTML +=
-        `<br><div><b>area</b>: ${Math.round(area * 1000) /
-          1000}m<sup>2</sup></div>` +
-        `<div><b>volume</b>: ${Math.round(
-          area * properties['height_ag'] * 1000
-        ) / 1000}m<sup>3</sup></div>`;
+      innerHTML += `<div><b>Name</b>: ${properties.Name}</div><br />`;
+      Object.keys(properties)
+        .sort()
+        .forEach(key => {
+          if (key != 'Name')
+            innerHTML += `<div><b>${key}</b>: ${properties[key]}</div>`;
+        });
+      let area = Math.round(calcArea(object) * 1000) / 1000;
+      innerHTML += `<br><div><b>Floor Area</b>: ${area}m<sup>2</sup></div>`;
+      if (layer.id === 'zone')
+        innerHTML += `<div><b>GFA</b>: ${Math.round(
+          (properties['floors_ag'] + properties['floors_bg']) * area * 1000
+        ) / 1000}m<sup>2</sup></div>`;
     } else if (layer.id === 'dc' || layer.id === 'dh') {
       Object.keys(properties).forEach(key => {
         if (key !== 'Building' && properties[key] === 'NONE') return null;

--- a/src/renderer/components/Project/NewProjectModal.js
+++ b/src/renderer/components/Project/NewProjectModal.js
@@ -36,6 +36,7 @@ const NewProjectModal = ({
           setVisible(false);
         } catch (err) {
           console.log(err.response);
+        } finally {
           setConfirmLoading(false);
         }
       }

--- a/src/renderer/components/Project/OpenProjectModal.js
+++ b/src/renderer/components/Project/OpenProjectModal.js
@@ -27,6 +27,7 @@ const OpenProjectModal = ({
           setVisible(false);
         } catch (err) {
           console.log(err.response);
+        } finally {
           setConfirmLoading(false);
         }
       }

--- a/src/renderer/reducers/inputEditor.js
+++ b/src/renderer/reducers/inputEditor.js
@@ -177,13 +177,13 @@ function updateDaySchedule(state, buildings, tab, day, hour, value) {
       changes,
       'schedules',
       building,
-      `${tab}_${day}_${hour}`,
-      schedules[building].SCHEDULES[tab][day][Number(hour)],
+      `${tab}_${day}_${hour + 1}`,
+      schedules[building].SCHEDULES[tab][day][hour],
       value
     );
 
     let daySchedule = schedules[building].SCHEDULES[tab][day];
-    daySchedule[Number(hour)] = value;
+    daySchedule[hour] = value;
     schedules = {
       ...schedules,
       [building]: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2695,6 +2695,11 @@ ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.1, ajv@^6.10.2, ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
+almost-equal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/almost-equal/-/almost-equal-1.1.0.tgz#f851c631138757994276aa2efbe8dfa3066cccdd"
+  integrity sha1-+FHGMROHV5lCdqou++jfowZszN0=
+
 alphanum-sort@^1.0.1, alphanum-sort@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/alphanum-sort/-/alphanum-sort-1.0.2.tgz#97a1119649b211ad33691d9f9f486a8ec9fbe0a3"
@@ -3623,6 +3628,11 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+clamp@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/clamp/-/clamp-1.0.1.tgz#66a0e64011816e37196828fdc8c8c147312c8634"
+  integrity sha1-ZqDmQBGBbjcZaCj9yMjBRzEshjQ=
+
 clap@^1.0.9:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/clap/-/clap-1.2.3.tgz#4f36745b32008492557f46412d66d50cb99bce51"
@@ -3740,6 +3750,16 @@ color-convert@^1.3.0, color-convert@^1.9.0:
   dependencies:
     color-name "1.1.3"
 
+color-interpolate@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/color-interpolate/-/color-interpolate-1.0.5.tgz#d5710ce4244bd8b9feeda003f409edd4073b6217"
+  integrity sha512-EcWwYtBJdbeHyYq/y5QwVWLBUm4s7+8K37ycgO9OdY6YuAEa0ywAY+ItlAxE1UO5bXW4ugxNhStTV3rsTZ35ZA==
+  dependencies:
+    clamp "^1.0.1"
+    color-parse "^1.2.0"
+    color-space "^1.14.3"
+    lerp "^1.0.3"
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
@@ -3749,6 +3769,23 @@ color-name@^1.0.0:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+color-parse@^1.2.0:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/color-parse/-/color-parse-1.3.8.tgz#eaf54cd385cb34c0681f18c218aca38478082fa3"
+  integrity sha512-1Y79qFv0n1xair3lNMTNeoFvmc3nirMVBij24zbs1f13+7fPpQClMg5b4AuKXLt3szj7BRlHMCXHplkce6XlmA==
+  dependencies:
+    color-name "^1.0.0"
+    defined "^1.0.0"
+    is-plain-obj "^1.1.0"
+
+color-space@^1.14.3:
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/color-space/-/color-space-1.16.0.tgz#611781bca41cd8582a1466fd9e28a7d3d89772a2"
+  integrity sha512-A6WMiFzunQ8KEPFmj02OnnoUnqhmSaHaZ/0LVFcPTdlvm8+3aMJ5x1HRHy3bDHPkovkf4sS0f4wsVvwk71fKkg==
+  dependencies:
+    hsluv "^0.0.3"
+    mumath "^3.3.4"
 
 color-string@^0.3.0:
   version "0.3.0"
@@ -6153,6 +6190,11 @@ hpack.js@^2.1.6:
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
 
+hsluv@^0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/hsluv/-/hsluv-0.0.3.tgz#829107dafb4a9f8b52a1809ed02e091eade6754c"
+  integrity sha1-gpEH2vtKn4tSoYCe0C4JHq3mdUw=
+
 html-comment-regex@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7"
@@ -6734,7 +6776,7 @@ is-path-inside@^2.1.0:
   dependencies:
     path-is-inside "^1.0.2"
 
-is-plain-obj@^1.0.0:
+is-plain-obj@^1.0.0, is-plain-obj@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-1.1.0.tgz#71a50c8429dfca773c92a390a4a03b39fcd51d3e"
   integrity sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
@@ -7048,6 +7090,11 @@ lcid@^2.0.0:
   integrity sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==
   dependencies:
     invert-kv "^2.0.0"
+
+lerp@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/lerp/-/lerp-1.0.3.tgz#a18c8968f917896de15ccfcc28d55a6b731e776e"
+  integrity sha1-oYyJaPkXiW3hXM/MKNVaa3Med24=
 
 levn@^0.3.0, levn@~0.3.0:
   version "0.3.0"
@@ -7652,6 +7699,13 @@ multicast-dns@^6.0.1:
   dependencies:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
+
+mumath@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/mumath/-/mumath-3.3.4.tgz#48d4a0f0fd8cad4e7b32096ee89b161a63d30bbf"
+  integrity sha1-SNSg8P2MrU57Mglu6JsWGmPTC78=
+  dependencies:
+    almost-equal "^1.1.0"
 
 murmurhash-js@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR adds editing and saving of schedules to the input editor.

Changes
-
- Add debouncing for fetching building schedules
- Add tooltips to column headers
- Any changes made to the schedules data in the input editor would be reflected in the respective files when saved
- Enable multi selection in table while holding ctrl
- Add colors to table cells based on its values to emulate a heat map
- Add **GFA** (gross floor area) to tooltips for zone buildings 
(closes https://github.com/architecture-building-systems/CityEnergyAnalyst/issues/2326)

Fixes
-
- Hour Header starting from 0 instead of 1


(build link: https://we.tl/t-6gC0nQuuR0)