### PR TITLE
Use-type database in editor

### DIFF
--- a/src/renderer/components/DatabaseEditor/ColumnGlossary.js
+++ b/src/renderer/components/DatabaseEditor/ColumnGlossary.js
@@ -1,0 +1,56 @@
+import React, { useState, useEffect, useRef } from 'react';
+import ReactDOM from 'react-dom';
+import { useSelector } from 'react-redux';
+import './DatabaseEditor.css';
+import Handsontable from 'handsontable';
+
+const ColumnGlossary = ({ tableRef, colHeaders }) => {
+  const tooltipRef = useRef();
+  const dbGlossary = useSelector(state => state.databaseEditor.glossary);
+  const [tableGlossary, setTableGlossary] = useState([]);
+  const tooltipPrompt = (
+    <p className="cea-database-editor-column-tooltip">
+      <i>Hover over column headers to see their description.</i>
+    </p>
+  );
+
+  useEffect(() => {
+    setTableGlossary(
+      colHeaders
+        .map(col => dbGlossary.find(variable => col === variable.VARIABLE))
+        .filter(obj => typeof obj !== 'undefined')
+    );
+  }, []);
+
+  useEffect(() => {
+    if (tableGlossary.length) {
+      ReactDOM.render(tooltipPrompt, tooltipRef.current);
+      const tableInstance = tableRef.current.hotInstance;
+      Handsontable.hooks.add(
+        'afterOnCellMouseOver',
+        (e, coords, td) => {
+          if (coords.row == -1 && coords.col != -1) {
+            if (typeof tableGlossary[coords.col] !== 'undefined') {
+              const { VARIABLE, DESCRIPTION, UNIT } = tableGlossary[coords.col];
+              ReactDOM.render(
+                <p className="cea-database-editor-column-tooltip">
+                  <b>{VARIABLE}</b>
+                  {' : '}
+                  <i>{DESCRIPTION}</i>
+                  {' / UNIT: '}
+                  <span>{UNIT}</span>
+                </p>,
+                tooltipRef.current
+              );
+            }
+          }
+        },
+        tableInstance
+      );
+    }
+  }, [tableGlossary]);
+
+  return <div ref={tooltipRef}></div>;
+};
+
+export default ColumnGlossary;

--- a/src/renderer/components/DatabaseEditor/Database.js
+++ b/src/renderer/components/DatabaseEditor/Database.js
@@ -1,0 +1,88 @@
+import React, { useEffect, useRef } from 'react';
+import { Tabs } from 'antd';
+import { withErrorBoundary } from '../../utils/ErrorBoundary';
+import './DatabaseEditor.css';
+import Table, { TableButtons, useTableUpdateRedux } from './Table';
+import ColumnGlossary from './ColumnGlossary';
+
+const Database = ({ name, data, schema }) => {
+  return (
+    <Tabs className="cea-database-editor-tabs" type="card">
+      {Object.keys(data).map(sheetName => (
+        <Tabs.TabPane key={sheetName} tab={sheetName}>
+          <DatabaseTable
+            databaseName={name}
+            sheetName={sheetName}
+            sheetData={data[sheetName]}
+            schema={schema[sheetName]}
+          />
+        </Tabs.TabPane>
+      ))}
+    </Tabs>
+  );
+};
+
+const DatabaseTable = ({ databaseName, sheetName, sheetData, schema }) => {
+  const tableRef = useRef(null);
+  const updateRedux = useTableUpdateRedux(tableRef, databaseName, sheetName);
+  const { columns, colHeaders } = getTableSchema(schema, sheetName, sheetData);
+
+  // Validate cells on mount
+  useEffect(() => {
+    tableRef.current.hotInstance.validateCells();
+  }, []);
+
+  return (
+    <div className="cea-database-editor-sheet">
+      <TableButtons tableRef={tableRef} sheetData={sheetData} />
+      <ColumnGlossary tableRef={tableRef} colHeaders={colHeaders} />
+      <Table
+        ref={tableRef}
+        id={databaseName}
+        data={sheetData}
+        colHeaders={colHeaders}
+        rowHeaders={true}
+        columns={columns}
+        stretchH="all"
+        height={400}
+      />
+    </div>
+  );
+};
+
+const getTableSchema = (schema, sheetName, tableData) => {
+  const colHeaders = Object.keys(tableData[0]);
+  const columns = colHeaders.map(key => {
+    // Try to infer type from schema, else load default
+    if (
+      typeof schema[key] !== 'undefined' &&
+      Array.isArray(schema[key]['types_found'])
+    ) {
+      if (['long', 'float', 'int'].includes(schema[key]['types_found'][0])) {
+        // Accept 'NA' values for air_conditioning_systems
+        if (['HEATING', 'COOLING'].includes(sheetName))
+          return {
+            data: key,
+            type: 'numeric',
+            validator: (value, callback) => {
+              if (value === 'NA' || !isNaN(value)) {
+                callback(true);
+              } else {
+                callback(false);
+              }
+            }
+          };
+        else return { data: key, type: 'numeric' };
+      } else return { data: key };
+    } else {
+      console.error(`Could not find \`${key}\` in schema`, {
+        sheetName,
+        schema
+      });
+      return { data: key };
+    }
+  });
+  return { columns, colHeaders };
+};
+
+export default withErrorBoundary(Database);

--- a/src/renderer/components/DatabaseEditor/Database.js
+++ b/src/renderer/components/DatabaseEditor/Database.js
@@ -6,10 +6,12 @@ import Table, { TableButtons, useTableUpdateRedux } from './Table';
 import ColumnGlossary from './ColumnGlossary';
 
 const Database = ({ name, data, schema }) => {
+  const sheetNames = Object.keys(data);
+
   return (
     <Tabs className="cea-database-editor-tabs" type="card">
-      {Object.keys(data).map(sheetName => (
-        <Tabs.TabPane key={sheetName} tab={sheetName}>
+      {sheetNames.map(sheetName => (
+        <Tabs.TabPane key={`${name}-${sheetName}`} tab={sheetName}>
           <DatabaseTable
             databaseName={name}
             sheetName={sheetName}

--- a/src/renderer/components/DatabaseEditor/DatabaseEditor.js
+++ b/src/renderer/components/DatabaseEditor/DatabaseEditor.js
@@ -215,7 +215,7 @@ const DatabaseContainer = () => {
   return (
     <div className="cea-database-editor-database-container">
       <div className="cea-database-editor-database">
-        <h2>{name}</h2>
+        <h2>{name.replace('_', '-')}</h2>
         <ValidationErrors databaseName={name} />
         {name === 'USE_TYPES' ? (
           <UseTypesDatabase

--- a/src/renderer/components/DatabaseEditor/DatabaseEditor.js
+++ b/src/renderer/components/DatabaseEditor/DatabaseEditor.js
@@ -1,8 +1,7 @@
-import React, { useState, useEffect, useRef } from 'react';
-import ReactDOM from 'react-dom';
+import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import axios from 'axios';
-import { Tabs, Icon, Button, Modal, Menu, Alert } from 'antd';
+import { Icon, Button } from 'antd';
 import { withErrorBoundary } from '../../utils/ErrorBoundary';
 import CenterSpinner from '../HomePage/CenterSpinner';
 import ExportDatabaseModal from './ExportDatabaseModal';
@@ -10,17 +9,16 @@ import './DatabaseEditor.css';
 import {
   resetDatabaseState,
   initDatabaseState,
-  setActiveDatabase,
-  resetDatabaseChanges,
-  copyScheduleData
+  resetDatabaseChanges
 } from '../../actions/databaseEditor';
-import Table, { TableButtons, useTableUpdateRedux } from './Table';
-import { months_short } from '../../constants/months';
 import { AsyncError } from '../../utils';
 import routes from '../../constants/routes';
 import { useChangeRoute } from '../Project/Project';
-import Handsontable from 'handsontable';
-import NewScheduleModal from './NewScheduleModal';
+import SavingDatabaseModal from './SavingDatabaseModal';
+import DatabaseTopMenu from './DatabaseTopMenu';
+import Database from './Database';
+import UseTypesDatabase from './UseTypesDatabase';
+import ValidationErrors from './ValidationErrors';
 
 const useValidateDatabasePath = () => {
   const [valid, setValid] = useState(null);
@@ -46,93 +44,6 @@ const useValidateDatabasePath = () => {
   }, []);
 
   return [valid, error, checkDBPathValidity];
-};
-
-const ValidationErrors = ({ databaseName }) => {
-  const validation = useSelector(state => state.databaseEditor.validation);
-  if (typeof validation[databaseName] === 'undefined') return null;
-
-  return (
-    <div style={{ margin: 10 }}>
-      <Alert
-        message="Errors Found in Database"
-        description={
-          <div>
-            {Object.keys(validation[databaseName]).map(sheet => {
-              const rows = validation[databaseName][sheet];
-              return (
-                <div key={sheet}>
-                  {Object.keys(rows).map(row => (
-                    <div key={row}>
-                      <i>Sheet: </i>
-                      <b>{sheet} </b>
-                      <i>Row: </i>
-                      <b>{row} </b>
-                      <i>Columns: </i>
-                      <b>{Object.keys(rows[row]).join(', ')}</b>
-                    </div>
-                  ))}
-                </div>
-              );
-            })}
-          </div>
-        }
-        type="error"
-      />
-    </div>
-  );
-};
-
-const SavingDatabaseModal = ({ visible, hideModal, error, success }) => {
-  const goToScript = useChangeRoute(`${routes.TOOLS}/archetypes-mapper`);
-  return (
-    <Modal
-      visible={visible}
-      width={800}
-      onCancel={hideModal}
-      closable={false}
-      maskClosable={false}
-      destroyOnClose={true}
-      footer={
-        error ? (
-          <Button onClick={hideModal}>Back</Button>
-        ) : success ? (
-          [
-            <Button key="back" onClick={hideModal}>
-              Back
-            </Button>,
-            <ExportDatabaseButton key="export" />,
-            <Button key="script" type="primary" onClick={goToScript}>
-              Go to Archetypes Mapper
-            </Button>
-          ]
-        ) : null
-      }
-    >
-      {error ? (
-        <div>
-          <AsyncError error={error} />
-          <b>
-            <i>Changes were not saved</i>
-          </b>
-        </div>
-      ) : !success ? (
-        <div>
-          <Icon type="loading" style={{ color: 'blue', margin: 5 }} />
-          <span>Saving Databases</span>
-        </div>
-      ) : (
-        <div>
-          <h2>Changes Saved!</h2>
-          <p>You can now export this database to a desired path.</p>
-          <p>
-            Remember to run <i>Archetypes Mapper</i> to map properties from this
-            database to your geometries.
-          </p>
-        </div>
-      )}
-    </Modal>
-  );
 };
 
 const DatabaseEditor = () => {
@@ -205,13 +116,13 @@ const DatabaseContent = () => {
 
   return (
     <React.Fragment>
-      <DatabaseTabs />
+      <DatabaseTopMenu />
       <DatabaseContainer />
     </React.Fragment>
   );
 };
 
-const ExportDatabaseButton = () => {
+export const ExportDatabaseButton = () => {
   const { status } = useSelector(state => state.databaseEditor.status);
   const databaseValidation = useSelector(
     state => state.databaseEditor.validation
@@ -291,61 +202,6 @@ const SaveDatabaseButton = () => {
   );
 };
 
-const DatabaseTabs = () => {
-  const data = useSelector(state => state.databaseEditor.data);
-  const validation = useSelector(state => state.databaseEditor.validation);
-  const dispatch = useDispatch();
-  const [selectedKey, setSelected] = useState(
-    `${Object.keys(data)[0]}:${Object.keys(data[Object.keys(data)[0]])[0]}`
-  );
-  const [visible, setVisible] = useState(false);
-
-  const handleOk = () => {
-    setVisible(false);
-  };
-
-  useEffect(() => {
-    dispatch(setActiveDatabase(...selectedKey.split(':')));
-  }, [selectedKey]);
-
-  return (
-    <div className="cea-database-editor-database-menu">
-      <Menu
-        mode="horizontal"
-        onClick={({ key }) => {
-          // Show modal if changing database and there are validation errors
-          if (selectedKey !== key && !!Object.keys(validation).length)
-            setVisible(true);
-          else setSelected(key);
-        }}
-        selectedKeys={[selectedKey]}
-      >
-        {Object.keys(data).map(category => (
-          <Menu.SubMenu key={category} title={category.toUpperCase()}>
-            {Object.keys(data[category]).map(name => (
-              <Menu.Item key={`${category}:${name}`}>{name}</Menu.Item>
-            ))}
-          </Menu.SubMenu>
-        ))}
-      </Menu>
-      <Modal
-        centered
-        closable={false}
-        visible={visible}
-        footer={[
-          <Button key="back" onClick={handleOk}>
-            Go Back
-          </Button>
-        ]}
-      >
-        There are still errors in this database.
-        <br />
-        You would need to fix the errors before navigating to another database
-      </Modal>
-    </div>
-  );
-};
-
 const DatabaseContainer = () => {
   const data = useSelector(state => state.databaseEditor.data);
   const schema = useSelector(state => state.databaseEditor.schema);
@@ -358,26 +214,11 @@ const DatabaseContainer = () => {
 
   return (
     <div className="cea-database-editor-database-container">
-      {category === 'archetypes' && (
-        <div style={{ margin: 10 }}>
-          <Alert
-            message={
-              <div>
-                If you want to add a new <i>archetype</i>, you would need to
-                include it in all sheets of <b>CONSTRUCTION</b> and create its
-                schedule in <b>SCHEDULES</b>
-              </div>
-            }
-            type="info"
-            showIcon
-          />
-        </div>
-      )}
       <div className="cea-database-editor-database">
         <h2>{name}</h2>
         <ValidationErrors databaseName={name} />
-        {name === 'SCHEDULES' ? (
-          <SchedulesDatabase
+        {name === 'USE_TYPES' ? (
+          <UseTypesDatabase
             name={name}
             data={data[category][name]}
             schema={schema[category][name]}
@@ -391,332 +232,6 @@ const DatabaseContainer = () => {
         )}
       </div>
       <SaveDatabaseButton />
-    </div>
-  );
-};
-
-const Database = ({ name, data, schema }) => {
-  return (
-    <Tabs className="cea-database-editor-tabs" type="card">
-      {Object.keys(data).map(sheetName => (
-        <Tabs.TabPane key={sheetName} tab={sheetName}>
-          <DatabaseTable
-            databaseName={name}
-            sheetName={sheetName}
-            sheetData={data[sheetName]}
-            schema={schema[sheetName]}
-          />
-        </Tabs.TabPane>
-      ))}
-    </Tabs>
-  );
-};
-
-const SchedulesDatabase = ({ name, data, schema }) => {
-  const scheduleNames = Object.keys(data);
-  const [modalVisible, setModalVisible] = useState(false);
-  const [selectedKey, setSelected] = useState(scheduleNames[0]);
-  const [panes, setPanes] = useState(scheduleNames);
-  const dispatch = useDispatch();
-
-  const showModal = () => {
-    setModalVisible(true);
-  };
-
-  const onEdit = (targetKey, action) => {
-    if (action === 'remove') {
-      Modal.confirm({
-        title: `Do you want to delete ${targetKey} schedule?`,
-        content: 'This action cannot be undone.',
-        onOk() {
-          setSelected(null);
-          setPanes(oldValue => oldValue.filter(pane => pane != targetKey));
-        }
-      });
-    }
-  };
-
-  const addSchedule = values => {
-    const { name, copy } = values;
-    dispatch(copyScheduleData(name, copy));
-    setPanes(oldValue => [...oldValue, name]);
-    setSelected(name);
-  };
-
-  return (
-    <React.Fragment>
-      <Tabs
-        className="cea-database-editor-tabs"
-        type="editable-card"
-        onEdit={onEdit}
-        hideAdd
-        activeKey={selectedKey}
-        onChange={setSelected}
-        tabBarExtraContent={
-          <Button onClick={showModal}>Add new Archetype Schedule</Button>
-        }
-      >
-        {panes.map(pane => (
-          <Tabs.TabPane key={pane} tab={pane}>
-            <SchedulesTable
-              databaseName={name}
-              sheetName={pane}
-              sheetData={data[pane]}
-              schema={schema[pane]}
-            />
-          </Tabs.TabPane>
-        ))}
-      </Tabs>
-      <NewScheduleModal
-        scheduleNames={scheduleNames}
-        onSuccess={values => {
-          addSchedule(values);
-        }}
-        visible={modalVisible}
-        setVisible={setModalVisible}
-      />
-    </React.Fragment>
-  );
-};
-
-const getTableSchema = (schema, sheetName, tableData) => {
-  const colHeaders = Object.keys(tableData[0]);
-  const columns = colHeaders.map(key => {
-    // Try to infer type from schema, else load default
-    if (
-      typeof schema[key] !== 'undefined' &&
-      Array.isArray(schema[key]['types_found'])
-    ) {
-      if (['long', 'float', 'int'].includes(schema[key]['types_found'][0])) {
-        // Accept 'NA' values for air_conditioning_systems
-        if (['HEATING', 'COOLING'].includes(sheetName))
-          return {
-            data: key,
-            type: 'numeric',
-            validator: (value, callback) => {
-              if (value === 'NA' || !isNaN(value)) {
-                callback(true);
-              } else {
-                callback(false);
-              }
-            }
-          };
-        else return { data: key, type: 'numeric' };
-      } else return { data: key };
-    } else {
-      console.error(`Could not find \`${key}\` in schema`, {
-        sheetName,
-        schema
-      });
-      return { data: key };
-    }
-  });
-  return { columns, colHeaders };
-};
-
-const ColumnGlossary = ({ tableRef, colHeaders }) => {
-  const tooltipRef = useRef();
-  const dbGlossary = useSelector(state => state.databaseEditor.glossary);
-  const [tableGlossary, setTableGlossary] = useState([]);
-  const tooltipPrompt = (
-    <p className="cea-database-editor-column-tooltip">
-      <i>Hover over column headers to see their description.</i>
-    </p>
-  );
-
-  useEffect(() => {
-    setTableGlossary(
-      colHeaders
-        .map(col => dbGlossary.find(variable => col === variable.VARIABLE))
-        .filter(obj => typeof obj !== 'undefined')
-    );
-  }, []);
-
-  useEffect(() => {
-    if (tableGlossary.length) {
-      ReactDOM.render(tooltipPrompt, tooltipRef.current);
-      const tableInstance = tableRef.current.hotInstance;
-      Handsontable.hooks.add(
-        'afterOnCellMouseOver',
-        (e, coords, td) => {
-          if (coords.row == -1 && coords.col != -1) {
-            if (typeof tableGlossary[coords.col] !== 'undefined') {
-              const { VARIABLE, DESCRIPTION, UNIT } = tableGlossary[coords.col];
-              ReactDOM.render(
-                <p className="cea-database-editor-column-tooltip">
-                  <b>{VARIABLE}</b>
-                  {' : '}
-                  <i>{DESCRIPTION}</i>
-                  {' / UNIT: '}
-                  <span>{UNIT}</span>
-                </p>,
-                tooltipRef.current
-              );
-            }
-          }
-        },
-        tableInstance
-      );
-    }
-  }, [tableGlossary]);
-
-  return <div ref={tooltipRef}></div>;
-};
-
-const DatabaseTable = ({ databaseName, sheetName, sheetData, schema }) => {
-  const tableRef = useRef(null);
-  const updateRedux = useTableUpdateRedux(tableRef, databaseName, sheetName);
-  const { columns, colHeaders } = getTableSchema(schema, sheetName, sheetData);
-
-  // Validate cells on mount
-  useEffect(() => {
-    tableRef.current.hotInstance.validateCells();
-  }, []);
-
-  return (
-    <div className="cea-database-editor-sheet">
-      <TableButtons tableRef={tableRef} sheetData={sheetData} />
-      <ColumnGlossary tableRef={tableRef} colHeaders={colHeaders} />
-      <Table
-        ref={tableRef}
-        id={databaseName}
-        data={sheetData}
-        colHeaders={colHeaders}
-        rowHeaders={true}
-        columns={columns}
-        stretchH="all"
-        height={400}
-      />
-    </div>
-  );
-};
-
-const SchedulesTable = ({ databaseName, sheetName, sheetData, schema }) => {
-  return (
-    <div className="cea-database-editor-schedules-sheet">
-      <p>Yearly/Month</p>
-      <SchedulesYearTable
-        databaseName={databaseName}
-        sheetName={sheetName}
-        yearData={sheetData['MONTHLY_MULTIPLIER']}
-      />
-      <p>Day/Hour</p>
-      <SchedulesTypeTab
-        databaseName={databaseName}
-        sheetName={sheetName}
-        scheduleData={sheetData['SCHEDULES']}
-      />
-    </div>
-  );
-};
-
-const SchedulesTypeTab = ({ databaseName, sheetName, scheduleData }) => {
-  const [selectedType, setSelected] = useState(Object.keys(scheduleData)[0]);
-  return (
-    <div>
-      <SchedulesDataTable
-        databaseName={databaseName}
-        sheetName={sheetName}
-        scheduleType={selectedType}
-        data={scheduleData[selectedType]}
-      />
-      <Tabs
-        className="cea-database-editor-tabs"
-        size="small"
-        animated={false}
-        tabPosition="bottom"
-        activeKey={selectedType}
-        onChange={setSelected}
-      >
-        {Object.keys(scheduleData).map(scheduleType => (
-          <Tabs.TabPane key={scheduleType} tab={scheduleType}></Tabs.TabPane>
-        ))}
-      </Tabs>
-    </div>
-  );
-};
-
-const fractionFloatValidator = (value, callback) => {
-  try {
-    if (Number(value) >= 0 && Number(value) <= 1) callback(true);
-    else callback(false);
-  } catch (error) {
-    callback(false);
-  }
-};
-
-const SchedulesYearTable = ({ databaseName, sheetName, yearData }) => {
-  const tableRef = useRef();
-  const updateRedux = useTableUpdateRedux(tableRef, databaseName, sheetName);
-  const colHeaders = Object.keys(yearData).map(i => months_short[i]);
-  const columns = Object.keys(colHeaders).map(key => ({
-    data: Number(key),
-    type: 'numeric',
-    validator: fractionFloatValidator
-  }));
-
-  //  Revalidate cells on sheet change
-  useEffect(() => {
-    tableRef.current.hotInstance.validateCells();
-  }, [sheetName]);
-
-  return (
-    <div className="cea-database-editor-schedule-year">
-      <Table
-        ref={tableRef}
-        id={`${databaseName}-${sheetName}-year`}
-        data={[yearData]}
-        rowHeaders="MONTHLY_MULTIPLIER"
-        rowHeaderWidth={180}
-        colHeaders={colHeaders}
-        columns={columns}
-        // stretchH="all"
-        height={70}
-      />
-    </div>
-  );
-};
-
-const SchedulesDataTable = ({
-  databaseName,
-  sheetName,
-  scheduleType,
-  data
-}) => {
-  const tableRef = useRef();
-  const updateRedux = useTableUpdateRedux(
-    tableRef,
-    databaseName,
-    `${sheetName}-${scheduleType}`
-  );
-  const rowHeaders = Object.keys(data);
-  const tableData = rowHeaders.map(row => data[row]);
-  const colHeaders = Object.keys(tableData[0]).map(i => Number(i) + 1);
-  const columns = Object.keys(colHeaders).map(key => {
-    // FIXME: Temp solution
-    if (['HEATING', 'COOLING'].includes(scheduleType)) {
-      return { data: key };
-    } else return { data: key, type: 'numeric' };
-  });
-
-  //  Revalidate cells on sheet and type change
-  useEffect(() => {
-    tableRef.current.hotInstance.validateCells();
-  }, [sheetName, scheduleType]);
-
-  return (
-    <div className="cea-database-editor-schedule-data">
-      <Table
-        ref={tableRef}
-        id={`${databaseName}-${sheetName}-data`}
-        data={tableData}
-        rowHeaders={rowHeaders}
-        rowHeaderWidth={80}
-        colHeaders={colHeaders}
-        columns={columns}
-        // stretchH="all"
-        height={120}
-      />
     </div>
   );
 };

--- a/src/renderer/components/DatabaseEditor/DatabaseTopMenu.js
+++ b/src/renderer/components/DatabaseEditor/DatabaseTopMenu.js
@@ -1,0 +1,62 @@
+import React, { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { Button, Modal, Menu } from 'antd';
+import './DatabaseEditor.css';
+import { setActiveDatabase } from '../../actions/databaseEditor';
+
+const DatabaseTopMenu = () => {
+  const data = useSelector(state => state.databaseEditor.data);
+  const validation = useSelector(state => state.databaseEditor.validation);
+  const dispatch = useDispatch();
+  const [selectedKey, setSelected] = useState(
+    `${Object.keys(data)[0]}:${Object.keys(data[Object.keys(data)[0]])[0]}`
+  );
+  const [visible, setVisible] = useState(false);
+
+  const handleOk = () => {
+    setVisible(false);
+  };
+
+  useEffect(() => {
+    dispatch(setActiveDatabase(...selectedKey.split(':')));
+  }, [selectedKey]);
+
+  return (
+    <div className="cea-database-editor-database-menu">
+      <Menu
+        mode="horizontal"
+        onClick={({ key }) => {
+          // Show modal if changing database and there are validation errors
+          if (selectedKey !== key && !!Object.keys(validation).length)
+            setVisible(true);
+          else setSelected(key);
+        }}
+        selectedKeys={[selectedKey]}
+      >
+        {Object.keys(data).map(category => (
+          <Menu.SubMenu key={category} title={category.toUpperCase()}>
+            {Object.keys(data[category]).map(name => (
+              <Menu.Item key={`${category}:${name}`}>{name}</Menu.Item>
+            ))}
+          </Menu.SubMenu>
+        ))}
+      </Menu>
+      <Modal
+        centered
+        closable={false}
+        visible={visible}
+        footer={[
+          <Button key="back" onClick={handleOk}>
+            Go Back
+          </Button>
+        ]}
+      >
+        There are still errors in this database.
+        <br />
+        You would need to fix the errors before navigating to another database
+      </Modal>
+    </div>
+  );
+};
+
+export default DatabaseTopMenu;

--- a/src/renderer/components/DatabaseEditor/DatabaseTopMenu.js
+++ b/src/renderer/components/DatabaseEditor/DatabaseTopMenu.js
@@ -36,7 +36,9 @@ const DatabaseTopMenu = () => {
         {Object.keys(data).map(category => (
           <Menu.SubMenu key={category} title={category.toUpperCase()}>
             {Object.keys(data[category]).map(name => (
-              <Menu.Item key={`${category}:${name}`}>{name}</Menu.Item>
+              <Menu.Item key={`${category}:${name}`}>
+                {name.replace('_', '-')}
+              </Menu.Item>
             ))}
           </Menu.SubMenu>
         ))}

--- a/src/renderer/components/DatabaseEditor/SavingDatabaseModal.js
+++ b/src/renderer/components/DatabaseEditor/SavingDatabaseModal.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { Icon, Button, Modal } from 'antd';
+import { ExportDatabaseButton } from './DatabaseEditor';
+import './DatabaseEditor.css';
+import { AsyncError } from '../../utils';
+import routes from '../../constants/routes';
+import { useChangeRoute } from '../Project/Project';
+
+const SavingDatabaseModal = ({ visible, hideModal, error, success }) => {
+  const goToScript = useChangeRoute(`${routes.TOOLS}/archetypes-mapper`);
+  return (
+    <Modal
+      visible={visible}
+      width={800}
+      onCancel={hideModal}
+      closable={false}
+      maskClosable={false}
+      destroyOnClose={true}
+      footer={
+        error ? (
+          <Button onClick={hideModal}>Back</Button>
+        ) : success ? (
+          [
+            <Button key="back" onClick={hideModal}>
+              Back
+            </Button>,
+            <ExportDatabaseButton key="export" />,
+            <Button key="script" type="primary" onClick={goToScript}>
+              Go to Archetypes Mapper
+            </Button>
+          ]
+        ) : null
+      }
+    >
+      {error ? (
+        <div>
+          <AsyncError error={error} />
+          <b>
+            <i>Changes were not saved</i>
+          </b>
+        </div>
+      ) : !success ? (
+        <div>
+          <Icon type="loading" style={{ color: 'blue', margin: 5 }} />
+          <span>Saving Databases</span>
+        </div>
+      ) : (
+        <div>
+          <h2>Changes Saved!</h2>
+          <p>You can now export this database to a desired path.</p>
+          <p>
+            Remember to run <i>Archetypes Mapper</i> to map properties from this
+            database to your geometries.
+          </p>
+        </div>
+      )}
+    </Modal>
+  );
+};
+
+export default SavingDatabaseModal;

--- a/src/renderer/components/DatabaseEditor/UseTypesDatabase.js
+++ b/src/renderer/components/DatabaseEditor/UseTypesDatabase.js
@@ -1,0 +1,208 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useDispatch } from 'react-redux';
+import { Tabs, Button, Modal } from 'antd';
+import { withErrorBoundary } from '../../utils/ErrorBoundary';
+import './DatabaseEditor.css';
+import { copyScheduleData } from '../../actions/databaseEditor';
+import Table, { useTableUpdateRedux } from './Table';
+import { months_short } from '../../constants/months';
+import NewScheduleModal from './NewScheduleModal';
+
+const UseTypesDatabase = ({ name, data, schema }) => {
+  const useTypes = Object.keys(data['SCHEDULES']);
+  const [modalVisible, setModalVisible] = useState(false);
+  const [selectedKey, setSelected] = useState(useTypes[0]);
+  const [panes, setPanes] = useState(useTypes);
+  const dispatch = useDispatch();
+
+  const showModal = () => {
+    setModalVisible(true);
+  };
+
+  const onEdit = (targetKey, action) => {
+    if (action === 'remove') {
+      Modal.confirm({
+        title: `Do you want to delete ${targetKey} schedule?`,
+        content: 'This action cannot be undone.',
+        onOk() {
+          setSelected(null);
+          setPanes(oldValue => oldValue.filter(pane => pane != targetKey));
+        }
+      });
+    }
+  };
+
+  const addSchedule = values => {
+    const { name, copy } = values;
+    dispatch(copyScheduleData(name, copy));
+    setPanes(oldValue => [...oldValue, name]);
+    setSelected(name);
+  };
+
+  return (
+    <React.Fragment>
+      <Tabs
+        className="cea-database-editor-tabs"
+        type="editable-card"
+        onEdit={onEdit}
+        hideAdd
+        activeKey={selectedKey}
+        onChange={setSelected}
+        tabBarExtraContent={
+          <Button onClick={showModal}>Add new Use-Type</Button>
+        }
+      >
+        {panes.map(pane => (
+          <Tabs.TabPane key={pane} tab={pane}>
+            <SchedulesTable
+              databaseName={name}
+              sheetName={pane}
+              sheetData={data['SCHEDULES'][pane]}
+              schema={schema}
+            />
+          </Tabs.TabPane>
+        ))}
+      </Tabs>
+      <NewScheduleModal
+        scheduleNames={useTypes}
+        onSuccess={values => {
+          addSchedule(values);
+        }}
+        visible={modalVisible}
+        setVisible={setModalVisible}
+      />
+    </React.Fragment>
+  );
+};
+
+const SchedulesTable = ({ databaseName, sheetName, sheetData, schema }) => {
+  return (
+    <div className="cea-database-editor-schedules-sheet">
+      <p>Yearly/Month</p>
+      <SchedulesYearTable
+        databaseName={databaseName}
+        sheetName={sheetName}
+        yearData={sheetData['MONTHLY_MULTIPLIER']}
+      />
+      <p>Day/Hour</p>
+      <SchedulesTypeTab
+        databaseName={databaseName}
+        sheetName={sheetName}
+        scheduleData={sheetData['SCHEDULES']}
+      />
+    </div>
+  );
+};
+
+const SchedulesTypeTab = ({ databaseName, sheetName, scheduleData }) => {
+  const [selectedType, setSelected] = useState(Object.keys(scheduleData)[0]);
+  return (
+    <div>
+      <SchedulesDataTable
+        databaseName={databaseName}
+        sheetName={sheetName}
+        scheduleType={selectedType}
+        data={scheduleData[selectedType]}
+      />
+      <Tabs
+        className="cea-database-editor-tabs"
+        size="small"
+        animated={false}
+        tabPosition="bottom"
+        activeKey={selectedType}
+        onChange={setSelected}
+      >
+        {Object.keys(scheduleData).map(scheduleType => (
+          <Tabs.TabPane key={scheduleType} tab={scheduleType}></Tabs.TabPane>
+        ))}
+      </Tabs>
+    </div>
+  );
+};
+
+const fractionFloatValidator = (value, callback) => {
+  try {
+    if (Number(value) >= 0 && Number(value) <= 1) callback(true);
+    else callback(false);
+  } catch (error) {
+    callback(false);
+  }
+};
+
+const SchedulesYearTable = ({ databaseName, sheetName, yearData }) => {
+  const tableRef = useRef();
+  const updateRedux = useTableUpdateRedux(tableRef, databaseName, sheetName);
+  const colHeaders = Object.keys(yearData).map(i => months_short[i]);
+  const columns = Object.keys(colHeaders).map(key => ({
+    data: Number(key),
+    type: 'numeric',
+    validator: fractionFloatValidator
+  }));
+
+  //  Revalidate cells on sheet change
+  useEffect(() => {
+    tableRef.current.hotInstance.validateCells();
+  }, [sheetName]);
+
+  return (
+    <div className="cea-database-editor-schedule-year">
+      <Table
+        ref={tableRef}
+        id={`${databaseName}-${sheetName}-year`}
+        data={[yearData]}
+        rowHeaders="MONTHLY_MULTIPLIER"
+        rowHeaderWidth={180}
+        colHeaders={colHeaders}
+        columns={columns}
+        // stretchH="all"
+        height={70}
+      />
+    </div>
+  );
+};
+
+const SchedulesDataTable = ({
+  databaseName,
+  sheetName,
+  scheduleType,
+  data
+}) => {
+  const tableRef = useRef();
+  const updateRedux = useTableUpdateRedux(
+    tableRef,
+    databaseName,
+    `${sheetName}-${scheduleType}`
+  );
+  const rowHeaders = Object.keys(data);
+  const tableData = rowHeaders.map(row => data[row]);
+  const colHeaders = Object.keys(tableData[0]).map(i => Number(i) + 1);
+  const columns = Object.keys(colHeaders).map(key => {
+    // FIXME: Temp solution
+    if (['HEATING', 'COOLING'].includes(scheduleType)) {
+      return { data: key };
+    } else return { data: key, type: 'numeric' };
+  });
+
+  //  Revalidate cells on sheet and type change
+  useEffect(() => {
+    tableRef.current.hotInstance.validateCells();
+  }, [sheetName, scheduleType]);
+
+  return (
+    <div className="cea-database-editor-schedule-data">
+      <Table
+        ref={tableRef}
+        id={`${databaseName}-${sheetName}-data`}
+        data={tableData}
+        rowHeaders={rowHeaders}
+        rowHeaderWidth={80}
+        colHeaders={colHeaders}
+        columns={columns}
+        // stretchH="all"
+        height={120}
+      />
+    </div>
+  );
+};
+
+export default withErrorBoundary(UseTypesDatabase);

--- a/src/renderer/components/DatabaseEditor/ValidationErrors.js
+++ b/src/renderer/components/DatabaseEditor/ValidationErrors.js
@@ -1,0 +1,42 @@
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { Alert } from 'antd';
+import { withErrorBoundary } from '../../utils/ErrorBoundary';
+import './DatabaseEditor.css';
+
+const ValidationErrors = ({ databaseName }) => {
+  const validation = useSelector(state => state.databaseEditor.validation);
+  if (typeof validation[databaseName] === 'undefined') return null;
+
+  return (
+    <div style={{ margin: 10 }}>
+      <Alert
+        message="Errors Found in Database"
+        description={
+          <div>
+            {Object.keys(validation[databaseName]).map(sheet => {
+              const rows = validation[databaseName][sheet];
+              return (
+                <div key={sheet}>
+                  {Object.keys(rows).map(row => (
+                    <div key={row}>
+                      <i>Sheet: </i>
+                      <b>{sheet} </b>
+                      <i>Row: </i>
+                      <b>{row} </b>
+                      <i>Columns: </i>
+                      <b>{Object.keys(rows[row]).join(', ')}</b>
+                    </div>
+                  ))}
+                </div>
+              );
+            })}
+          </div>
+        }
+        type="error"
+      />
+    </div>
+  );
+};
+
+export default withErrorBoundary(ValidationErrors);


### PR DESCRIPTION
This PR consists of refactoring the **DatabaseEditor** component and introducing the changes of `SCHEDULES` database view to `USE-TYPES` to show schedule, indoor comfort and internal loads data.