### PR TITLE
Update database editor column glossary

### DIFF
--- a/src/renderer/components/DatabaseEditor/ColumnGlossary.js
+++ b/src/renderer/components/DatabaseEditor/ColumnGlossary.js
@@ -5,7 +5,7 @@ import './DatabaseEditor.css';
 import Handsontable from 'handsontable';
 import { withErrorBoundary } from '../../utils/ErrorBoundary';
 
-const ColumnGlossary = ({ tableRef, colHeaders }) => {
+const ColumnGlossary = ({ tableRef, colHeaders, filter }) => {
   const tooltipRef = useRef();
   const dbGlossary = useSelector(state => state.databaseEditor.glossary);
   const [tableGlossary, setTableGlossary] = useState([]);
@@ -16,9 +16,13 @@ const ColumnGlossary = ({ tableRef, colHeaders }) => {
   );
 
   useEffect(() => {
+    const _dbGlossary =
+      typeof filter === 'function'
+        ? dbGlossary.filter(variable => filter(variable))
+        : dbGlossary;
     setTableGlossary(
       colHeaders
-        .map(col => dbGlossary.find(variable => col === variable.VARIABLE))
+        .map(col => _dbGlossary.find(variable => col === variable.VARIABLE))
         .filter(obj => typeof obj !== 'undefined')
     );
   }, []);

--- a/src/renderer/components/DatabaseEditor/Database.js
+++ b/src/renderer/components/DatabaseEditor/Database.js
@@ -48,7 +48,11 @@ const DatabaseTable = ({ databaseName, sheetName, sheetData, schema }) => {
         databaseName={databaseName}
         sheetName={sheetName}
       />
-      <ColumnGlossary tableRef={tableRef} colHeaders={colHeaders} />
+      <ColumnGlossary
+        tableRef={tableRef}
+        colHeaders={colHeaders}
+        filter={variable => variable.WORKSHEET == sheetName}
+      />
       <Table
         ref={tableRef}
         id={databaseName}

--- a/src/renderer/components/DatabaseEditor/Database.js
+++ b/src/renderer/components/DatabaseEditor/Database.js
@@ -136,11 +136,16 @@ export const getTableSchema = (
           data: key,
           type: 'numeric',
           validator: (value, callback) => {
-            const min = column_schema['min'];
-            const max = column_schema['max'];
-            if (typeof min != 'undefined' && value < min) callback(false);
-            else if (typeof max != 'undefined' && value > max) callback(false);
-            else callback(true);
+            if (!isNaN(value)) {
+              const min = column_schema['min'];
+              const max = column_schema['max'];
+              const inRange =
+                (typeof min == 'undefined' || value >= min) &&
+                (typeof max == 'undefined' || value <= max);
+              callback(inRange);
+            } else {
+              callback(false);
+            }
           }
         };
     } else if (column_schema['type'] == 'boolean')

--- a/src/renderer/reducers/databaseEditor.js
+++ b/src/renderer/reducers/databaseEditor.js
@@ -44,7 +44,8 @@ const databaseGlossary = (state = [], { type, payload }) => {
   switch (type) {
     case FETCH_DATABASE_GLOSSARY_SUCCESS:
       try {
-        return payload.find(script => script.script === 'inputs').variables;
+        return payload.find(script => script.script === 'data_initializer')
+          .variables;
       } catch (err) {
         console.log(err);
         return [];


### PR DESCRIPTION
This PR works with https://github.com/architecture-building-systems/CityEnergyAnalyst/pull/2673, which includes changes to allow the column glossary in database editor to work with the new format.

This also fixes an issue in the numerical validator not checking if the value is numeric.