### PR TITLE
Maintain own project state

### DIFF
--- a/src/renderer/actions/project.js
+++ b/src/renderer/actions/project.js
@@ -4,14 +4,21 @@ export const GET_PROJECT = 'GET_PROJECT';
 export const GET_PROJECT_SUCCESS = 'GET_PROJECT_SUCCESS';
 export const GET_PROJECT_FAILED = 'GET_PROJECT_FAILED';
 
-export const getProject = () => {
+export const getProject = (projectPath = null) => {
   return (dispatch) => {
     dispatch({
       type: GET_PROJECT,
       payload: { isFetching: true, error: null },
     });
+    const config = projectPath
+      ? {
+          params: {
+            path: projectPath,
+          },
+        }
+      : {};
     return axios
-      .get(`http://localhost:5050/api/project`)
+      .get(`http://localhost:5050/api/project`, config)
       .then((response) => {
         dispatch({
           type: GET_PROJECT_SUCCESS,

--- a/src/renderer/actions/project.js
+++ b/src/renderer/actions/project.js
@@ -34,3 +34,10 @@ export const getProject = (projectPath = null) => {
       });
   };
 };
+
+export const UPDATE_SCENARIO = 'UPDATE_SCENARIO';
+
+export const updateScenario = (scenario) => ({
+  type: UPDATE_SCENARIO,
+  payload: { scenario },
+});

--- a/src/renderer/actions/project.js
+++ b/src/renderer/actions/project.js
@@ -4,19 +4,13 @@ export const GET_PROJECT = 'GET_PROJECT';
 export const GET_PROJECT_SUCCESS = 'GET_PROJECT_SUCCESS';
 export const GET_PROJECT_FAILED = 'GET_PROJECT_FAILED';
 
-export const getProject = (projectPath = null) => {
+export const getProject = (project = null) => {
   return (dispatch) => {
     dispatch({
       type: GET_PROJECT,
       payload: { isFetching: true, error: null },
     });
-    const config = projectPath
-      ? {
-          params: {
-            path: projectPath,
-          },
-        }
-      : {};
+    const config = project ? { params: { project } } : {};
     return axios
       .get(`http://localhost:5050/api/project`, config)
       .then((response) => {
@@ -37,7 +31,7 @@ export const getProject = (projectPath = null) => {
 
 export const UPDATE_SCENARIO = 'UPDATE_SCENARIO';
 
-export const updateScenario = (scenario) => ({
+export const updateScenario = (scenarioName) => ({
   type: UPDATE_SCENARIO,
-  payload: { scenario },
+  payload: { scenario_name: scenarioName },
 });

--- a/src/renderer/components/HomePage/Header.js
+++ b/src/renderer/components/HomePage/Header.js
@@ -8,7 +8,10 @@ const { Header: AntHeader } = Layout;
 
 const Header = () => {
   const { collapsed } = useSelector((state) => state.sider);
-  const { name, scenario } = useSelector((state) => state.project.info);
+  const {
+    project_name: projectName,
+    scenario_name: scenarioName,
+  } = useSelector((state) => state.project.info);
   const { pathname } = useSelector((state) => state.router.location);
   const dispatch = useDispatch();
 
@@ -43,11 +46,11 @@ const Header = () => {
           >
             <span>
               <i>Current Project: </i>
-              <b>{name}</b>
+              <b>{projectName}</b>
             </span>
             <span>
               <i>Scenario: </i>
-              <b>{scenario}</b>
+              <b>{scenarioName}</b>
             </span>
           </span>
         )}

--- a/src/renderer/components/HomePage/SideNav.js
+++ b/src/renderer/components/HomePage/SideNav.js
@@ -183,7 +183,7 @@ const SideNav = () => {
 
 const ScenarioMenuItem = ({ children, ...props }) => {
   const { scenario } = useSelector((state) => state.project.info);
-  if (scenario === '') return null;
+  if (scenario === null) return null;
   return React.Children.map(children, (child) =>
     React.cloneElement(child, { ...props })
   );

--- a/src/renderer/components/HomePage/SideNav.js
+++ b/src/renderer/components/HomePage/SideNav.js
@@ -182,8 +182,8 @@ const SideNav = () => {
 };
 
 const ScenarioMenuItem = ({ children, ...props }) => {
-  const { scenario } = useSelector((state) => state.project.info);
-  if (scenario === null) return null;
+  const scenarioName = useSelector((state) => state.project.info.scenario_name);
+  if (scenarioName === null) return null;
   return React.Children.map(children, (child) =>
     React.cloneElement(child, { ...props })
   );

--- a/src/renderer/components/Landing/Landing.js
+++ b/src/renderer/components/Landing/Landing.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { push } from 'connected-react-router';
 import { Button, Icon } from 'antd';

--- a/src/renderer/components/Landing/Landing.js
+++ b/src/renderer/components/Landing/Landing.js
@@ -2,8 +2,6 @@ import React, { useState, useEffect } from 'react';
 import { useDispatch } from 'react-redux';
 import { push } from 'connected-react-router';
 import { Button, Icon } from 'antd';
-import axios from 'axios';
-import { remote } from 'electron';
 import getStatic from '../../utils/static';
 import NewProjectModal from '../Project/NewProjectModal';
 import OpenProjectModal from '../Project/OpenProjectModal';
@@ -11,81 +9,71 @@ import routes from '../../constants/routes';
 
 const logo = getStatic('cea-logo.png');
 
-const useProjectInfo = (initialValue) => {
-  const [info, setInfo] = useState(initialValue);
-
-  useEffect(() => {
-    const fetchInfo = async () => {
-      try {
-        const resp = await axios.get('http://localhost:5050/api/project/');
-        setInfo(resp.data);
-      } catch (error) {
-        console.log(error);
-      }
-    };
-    fetchInfo();
-  }, []);
-
-  return info;
+const Landing = () => {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+      }}
+    >
+      <img src={logo} style={{ width: '15%', minWidth: 100 }} alt="CEA Logo" />
+      <h2 style={{ fontSize: '2em', margin: 30 }}>City Energy Analyst</h2>
+      <NewProjectModalButton />
+      <OpenProjectModalButton />
+    </div>
+  );
 };
 
-const Landing = () => {
-  const [visibleNew, setNewVisible] = useState(false);
-  const [visibleOpen, setOpenVisible] = useState(false);
+const NewProjectModalButton = () => {
+  const [visible, setVisible] = useState(false);
   const dispatch = useDispatch();
 
-  const { path: projectPath } = useProjectInfo({ path: null });
-
-  const goToProjectPage = async () => {
+  const goToProjectPage = () => {
     dispatch(push(routes.PROJECT_OVERVIEW));
   };
 
   return (
     <React.Fragment>
-      <div
-        style={{
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-        }}
+      <Button
+        type="primary"
+        style={{ width: 300, margin: 24 }}
+        onClick={() => setVisible(true)}
       >
-        <img
-          src={logo}
-          style={{ width: '15%', minWidth: 100 }}
-          alt="CEA Logo"
-        />
-        <h2 style={{ fontSize: '2em', margin: 30 }}>City Energy Analyst</h2>
-        <Button
-          type="primary"
-          style={{ width: 300, margin: 24 }}
-          onClick={() => setNewVisible(true)}
-        >
-          <Icon type="plus" />
-          New Project
-        </Button>
-        <Button
-          type="primary"
-          style={{ width: 300, margin: 24 }}
-          onClick={() => setOpenVisible(true)}
-        >
-          <Icon type="folder-open" />
-          Open Project
-        </Button>
-      </div>
+        <Icon type="plus" />
+        New Project
+      </Button>
       <NewProjectModal
-        visible={visibleNew}
-        setVisible={setNewVisible}
-        initialValue={
-          projectPath
-            ? require('path').dirname(projectPath)
-            : remote.app.getPath('home')
-        }
+        visible={visible}
+        setVisible={setVisible}
         onSuccess={goToProjectPage}
       />
+    </React.Fragment>
+  );
+};
+
+const OpenProjectModalButton = () => {
+  const [visible, setVisible] = useState(false);
+  const dispatch = useDispatch();
+
+  const goToProjectPage = () => {
+    dispatch(push(routes.PROJECT_OVERVIEW));
+  };
+
+  return (
+    <React.Fragment>
+      <Button
+        type="primary"
+        style={{ width: 300, margin: 24 }}
+        onClick={() => setVisible(true)}
+      >
+        <Icon type="folder-open" />
+        Open Project
+      </Button>
       <OpenProjectModal
-        visible={visibleOpen}
-        setVisible={setOpenVisible}
-        initialValue={projectPath}
+        visible={visible}
+        setVisible={setVisible}
         onSuccess={goToProjectPage}
       />
     </React.Fragment>

--- a/src/renderer/components/Project/NewProjectModal.js
+++ b/src/renderer/components/Project/NewProjectModal.js
@@ -5,15 +5,15 @@ import path from 'path';
 import axios from 'axios';
 import { FormItemWrapper, OpenDialogInput } from '../Tools/Parameter';
 import { remote } from 'electron';
-import { useConfigProjectInfo, useFetchProject } from '../Project/Project';
+import { useFetchConfigProjectInfo, useFetchProject } from '../Project/Project';
 
 const NewProjectModal = ({ visible, setVisible, onSuccess = () => {} }) => {
   const [confirmLoading, setConfirmLoading] = useState(false);
   const formRef = useRef();
   const {
-    info: { path: projectPath },
+    info: { project },
     fetchInfo,
-  } = useConfigProjectInfo();
+  } = useFetchConfigProjectInfo();
   const fetchProject = useFetchProject();
 
   useEffect(() => {
@@ -30,7 +30,8 @@ const NewProjectModal = ({ visible, setVisible, onSuccess = () => {} }) => {
             `http://localhost:5050/api/project/`,
             values
           );
-          fetchProject(resp.data.path).then(() => {
+          const { project } = resp.data;
+          fetchProject(project).then(() => {
             setConfirmLoading(false);
             setVisible(false);
             onSuccess();
@@ -61,8 +62,8 @@ const NewProjectModal = ({ visible, setVisible, onSuccess = () => {} }) => {
       <NewProjectForm
         ref={formRef}
         initialValue={
-          projectPath
-            ? require('path').dirname(projectPath)
+          project
+            ? require('path').dirname(project)
             : remote.app.getPath('home')
         }
       />
@@ -75,7 +76,7 @@ const NewProjectForm = Form.create()(({ form, initialValue }) => {
     <Form layout="horizontal">
       <FormItemWrapper
         form={form}
-        name="name"
+        name="project_name"
         initialValue=""
         help="Name of new Project"
         required={true}
@@ -84,7 +85,9 @@ const NewProjectForm = Form.create()(({ form, initialValue }) => {
             validator: (rule, value, callback) => {
               if (
                 value.length != 0 &&
-                fs.existsSync(path.join(form.getFieldValue('path'), value))
+                fs.existsSync(
+                  path.join(form.getFieldValue('project_root'), value)
+                )
               ) {
                 callback('Folder with name already exists in path');
               } else {
@@ -96,7 +99,7 @@ const NewProjectForm = Form.create()(({ form, initialValue }) => {
       />
       <FormItemWrapper
         form={form}
-        name="path"
+        name="project_root"
         initialValue={initialValue}
         help="Path of new Project"
         rules={[

--- a/src/renderer/components/Project/NewScenarioModal.js
+++ b/src/renderer/components/Project/NewScenarioModal.js
@@ -29,10 +29,10 @@ const NewScenarioModal = ({ visible, setVisible, project }) => {
         try {
           const resp = await axios.post(
             'http://localhost:5050/api/project/scenario/',
-            { projectPath: project.path, ...values }
+            { project, ...values }
           );
           console.log(resp.data);
-          openScenario(project.path, values.name);
+          openScenario(project, values.scenario_name);
         } catch (err) {
           console.log(err.response);
           setError(err.response);
@@ -76,12 +76,12 @@ const NewScenarioModal = ({ visible, setVisible, project }) => {
 
 const NewScenarioForm = Form.create()(
   ({ form, project, databaseParameter }) => {
-    const choice = form.getFieldValue('input-data');
+    const choice = form.getFieldValue('input_data');
 
     return (
       <Form>
         <Form.Item label={<h2 style={{ display: 'inline' }}>Scenario Name</h2>}>
-          {form.getFieldDecorator('name', {
+          {form.getFieldDecorator('scenario_name', {
             initialValue: '',
             rules: [
               { required: true },
@@ -89,7 +89,7 @@ const NewScenarioForm = Form.create()(
                 validator: (rule, value, callback) => {
                   if (
                     value.length != 0 &&
-                    fs.existsSync(path.join(project.path, value))
+                    fs.existsSync(path.join(project, value))
                   ) {
                     callback('Scenario with name already exists in project');
                   } else {
@@ -108,7 +108,7 @@ const NewScenarioForm = Form.create()(
 
         <h2>Input Data</h2>
         <Form.Item>
-          {form.getFieldDecorator('input-data', {
+          {form.getFieldDecorator('input_data', {
             initialValue: 'generate',
           })(
             <Radio.Group>
@@ -143,7 +143,7 @@ const useFetchDatabasePathParameter = () => {
               (p) => p.type === 'DatabasePathParameter'
             )
           ];
-        setParameter(dbPathParam);
+        setParameter({ ...dbPathParam, name: 'databases_path' });
       } catch (err) {
         console.log(err);
       }

--- a/src/renderer/components/Project/NewScenarioModal.js
+++ b/src/renderer/components/Project/NewScenarioModal.js
@@ -1,20 +1,14 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { Modal, Form, Radio, Input, Select } from 'antd';
+import { Modal, Form, Radio, Input } from 'antd';
 import fs from 'fs';
 import path from 'path';
 import axios from 'axios';
-import {
-  useOpenScenario,
-  useFetchProject,
-  useChangeRoute,
-  updateConfigProjectInfo,
-} from './Project';
+import { useOpenScenario } from './Project';
 import CreatingScenarioModal from './CreatingScenarioModal';
 import ScenarioGenerateDataForm from './ScenarioGenerateDataForm';
 import ScenarioImportDataForm from './ScenarioImportDataForm';
 import Parameter from '../Tools/Parameter';
 import { withErrorBoundary } from '../../utils/ErrorBoundary';
-import routes from '../../constants/routes';
 
 const NewScenarioModal = ({ visible, setVisible, project }) => {
   const [confirmLoading, setConfirmLoading] = useState(false);
@@ -22,8 +16,6 @@ const NewScenarioModal = ({ visible, setVisible, project }) => {
   const [error, setError] = useState(null);
   const formRef = useRef();
   const openScenario = useOpenScenario();
-  const fetchProject = useFetchProject();
-  const goToDBEditor = useChangeRoute(routes.DATABASE_EDITOR);
   const databaseParameter = useFetchDatabasePathParameter();
 
   const createScenario = (e) => {

--- a/src/renderer/components/Project/NewScenarioModal.js
+++ b/src/renderer/components/Project/NewScenarioModal.js
@@ -32,7 +32,7 @@ const NewScenarioModal = ({ visible, setVisible, project }) => {
             { project, ...values }
           );
           console.log(resp.data);
-          openScenario(project, values.scenario_name);
+          openScenario(project, values.scenario_name.trim());
         } catch (err) {
           console.log(err.response);
           setError(err.response);
@@ -84,7 +84,10 @@ const NewScenarioForm = Form.create()(
           {form.getFieldDecorator('scenario_name', {
             initialValue: '',
             rules: [
-              { required: true },
+              {
+                required: true,
+                transform: (value) => value.trim(),
+              },
               {
                 validator: (rule, value, callback) => {
                   if (

--- a/src/renderer/components/Project/NewScenarioModal.js
+++ b/src/renderer/components/Project/NewScenarioModal.js
@@ -37,7 +37,7 @@ const NewScenarioModal = ({ visible, setVisible, project }) => {
             );
             console.log(resp.data);
             if (values['databases-path'] !== 'create') {
-              openScenario(values.name);
+              openScenario(project, values.name);
             } else {
               await fetchProject();
               goToDBEditor();

--- a/src/renderer/components/Project/NewScenarioModal.js
+++ b/src/renderer/components/Project/NewScenarioModal.js
@@ -3,7 +3,12 @@ import { Modal, Form, Radio, Input, Select } from 'antd';
 import fs from 'fs';
 import path from 'path';
 import axios from 'axios';
-import { useOpenScenario, useFetchProject, useChangeRoute } from './Project';
+import {
+  useOpenScenario,
+  useFetchProject,
+  useChangeRoute,
+  updateConfigProjectInfo,
+} from './Project';
 import CreatingScenarioModal from './CreatingScenarioModal';
 import ScenarioGenerateDataForm from './ScenarioGenerateDataForm';
 import ScenarioImportDataForm from './ScenarioImportDataForm';
@@ -23,34 +28,27 @@ const NewScenarioModal = ({ visible, setVisible, project }) => {
 
   const createScenario = (e) => {
     setError(null);
-    formRef.current.validateFieldsAndScroll(
-      { scroll: { offsetTop: 60 } },
-      async (err, values) => {
-        if (!err) {
-          setConfirmLoading(true);
-          setModalVisible(true);
-          console.log('Received values of form: ', values);
-          try {
-            const resp = await axios.post(
-              'http://localhost:5050/api/project/scenario/',
-              values
-            );
-            console.log(resp.data);
-            if (values['databases-path'] !== 'create') {
-              openScenario(project, values.name);
-            } else {
-              await fetchProject();
-              goToDBEditor();
-            }
-          } catch (err) {
-            console.log(err.response);
-            setError(err.response);
-          } finally {
-            setConfirmLoading(false);
-          }
+    const formConfig = { scroll: { offsetTop: 60 } };
+    formRef.current.validateFieldsAndScroll(formConfig, async (err, values) => {
+      if (!err) {
+        setConfirmLoading(true);
+        setModalVisible(true);
+        console.log('Received values of form: ', values);
+        try {
+          const resp = await axios.post(
+            'http://localhost:5050/api/project/scenario/',
+            { projectPath: project.path, ...values }
+          );
+          console.log(resp.data);
+          openScenario(project.path, values.name);
+        } catch (err) {
+          console.log(err.response);
+          setError(err.response);
+        } finally {
+          setConfirmLoading(false);
         }
       }
-    );
+    });
   };
 
   const handleCancel = (e) => {

--- a/src/renderer/components/Project/OpenProjectModal.js
+++ b/src/renderer/components/Project/OpenProjectModal.js
@@ -2,15 +2,15 @@ import React, { useRef, useState, useEffect } from 'react';
 import { Modal, Form } from 'antd';
 import path from 'path';
 import { FormItemWrapper, OpenDialogInput } from '../Tools/Parameter';
-import { useConfigProjectInfo, useFetchProject } from '../Project/Project';
+import { useFetchConfigProjectInfo, useFetchProject } from '../Project/Project';
 
 const OpenProjectModal = ({ visible, setVisible, onSuccess = () => {} }) => {
   const [confirmLoading, setConfirmLoading] = useState(false);
   const formRef = useRef();
   const {
-    info: { path: projectPath },
+    info: { project },
     fetchInfo,
-  } = useConfigProjectInfo();
+  } = useFetchConfigProjectInfo();
   const fetchProject = useFetchProject();
 
   useEffect(() => {
@@ -22,7 +22,8 @@ const OpenProjectModal = ({ visible, setVisible, onSuccess = () => {} }) => {
       if (!err) {
         console.log('Received values of form: ', values);
         setConfirmLoading(true);
-        fetchProject(values.path).then(() => {
+        const { project } = values;
+        fetchProject(project).then(() => {
           setConfirmLoading(false);
           setVisible(false);
           onSuccess();
@@ -46,7 +47,7 @@ const OpenProjectModal = ({ visible, setVisible, onSuccess = () => {} }) => {
       confirmLoading={confirmLoading}
       destroyOnClose
     >
-      <OpenProjectForm ref={formRef} initialValue={projectPath} />
+      <OpenProjectForm ref={formRef} initialValue={project} />
     </Modal>
   );
 };
@@ -56,7 +57,7 @@ const OpenProjectForm = Form.create()(({ form, initialValue }) => {
     <Form>
       <FormItemWrapper
         form={form}
-        name="path"
+        name="project"
         initialValue={initialValue}
         help="Path of Project"
         rules={[

--- a/src/renderer/components/Project/Project.js
+++ b/src/renderer/components/Project/Project.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { push } from 'connected-react-router';
-import { Card, Button } from 'antd';
+import { Card, Button, message } from 'antd';
 import { getProject, updateScenario } from '../../actions/project';
 import axios from 'axios';
 import NewProjectModal from './NewProjectModal';
@@ -174,9 +174,24 @@ export const useOpenScenario = () => {
   const fetchProject = useFetchProject();
   const goToInputEditor = useChangeRoute(routes.INPUT_EDITOR);
   return (projectPath, scenario) => {
-    updateConfigProjectInfo(projectPath, scenario, () => {
-      // Fetch new project info first before going to input editor
-      fetchProject().then(goToInputEditor);
+    // Check if scenario still exist
+    fetchProject(projectPath).then((info) => {
+      const { scenarios } = info;
+      if (scenarios.includes(scenario))
+        updateConfigProjectInfo(projectPath, scenario, () => {
+          // Fetch new project info first before going to input editor
+          fetchProject().then(goToInputEditor);
+        });
+      else {
+        message.config({
+          top: 120,
+        });
+        message.error(
+          <span>
+            Scenario: <b>{scenario}</b> could not be found.
+          </span>
+        );
+      }
     });
   };
 };

--- a/src/renderer/components/Project/Project.js
+++ b/src/renderer/components/Project/Project.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { push } from 'connected-react-router';
 import { Card, Button } from 'antd';

--- a/src/renderer/components/Project/Project.js
+++ b/src/renderer/components/Project/Project.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { push } from 'connected-react-router';
 import { Card, Button } from 'antd';
-import { getProject } from '../../actions/project';
+import { getProject, updateScenario } from '../../actions/project';
 import axios from 'axios';
 import NewProjectModal from './NewProjectModal';
 import OpenProjectModal from './OpenProjectModal';
@@ -13,7 +13,6 @@ import './Project.css';
 
 const Project = () => {
   const { isFetching, error, info } = useSelector((state) => state.project);
-  const fetchProject = useFetchProject();
 
   const { name, path: projectPath, scenario, scenarios } = info;
   const projectExists = !error && name !== '';
@@ -29,14 +28,7 @@ const Project = () => {
             <div className="cea-project-options">
               <NewProjectButton />
               <OpenProjectButton />
-              <Button
-                icon="sync"
-                size="small"
-                onClick={() => fetchProject(projectPath)}
-                loading={isFetching}
-              >
-                Refresh
-              </Button>
+              <RefreshProjectButton project={info} loading={isFetching} />
             </div>
           </div>
         }
@@ -106,7 +98,26 @@ const OpenProjectButton = ({ onSuccess = () => {} }) => {
   );
 };
 
-const NewScenarioButton = ({ project = () => {} }) => {
+const RefreshProjectButton = ({ loading, project }) => {
+  const fetchProject = useFetchProject();
+  const dispatch = useDispatch();
+  const { path: projectPath, scenarios, scenario } = project;
+
+  const refreshProject = () => {
+    fetchProject(projectPath).then(() => {
+      // Set scenario back if it exists
+      if (scenarios.includes(scenario)) dispatch(updateScenario(scenario));
+    });
+  };
+
+  return (
+    <Button icon="sync" size="small" onClick={refreshProject} loading={loading}>
+      Refresh
+    </Button>
+  );
+};
+
+const NewScenarioButton = ({ project }) => {
   const [isModalVisible, setModalVisible] = useState(false);
 
   return (

--- a/src/renderer/components/Project/Project.js
+++ b/src/renderer/components/Project/Project.js
@@ -165,9 +165,7 @@ export const useOpenScenario = () => {
   return (projectPath, scenario) => {
     updateConfigProjectInfo(projectPath, scenario, () => {
       // Fetch new project info first before going to input editor
-      fetchProject().then(() => {
-        goToInputEditor();
-      });
+      fetchProject().then(goToInputEditor);
     });
   };
 };

--- a/src/renderer/components/Project/Project.js
+++ b/src/renderer/components/Project/Project.js
@@ -130,10 +130,15 @@ const NewScenarioButton = ({ project = () => {} }) => {
   );
 };
 
-export const changeScenario = async (scenario, onSuccess = () => {}) => {
+export const updateConfigProjectInfo = async (
+  projectPath,
+  scenario,
+  onSuccess = () => {}
+) => {
   try {
     const resp = await axios.put(`http://localhost:5050/api/project/`, {
-      scenario,
+      path: projectPath,
+      scenario: scenario,
     });
     console.log(resp.data);
     onSuccess();
@@ -157,11 +162,12 @@ export const deleteScenario = async (scenario, onSuccess = () => {}) => {
 export const useOpenScenario = () => {
   const fetchProject = useFetchProject();
   const goToInputEditor = useChangeRoute(routes.INPUT_EDITOR);
-  return (scenario) => {
-    changeScenario(scenario, async () => {
+  return (projectPath, scenario) => {
+    updateConfigProjectInfo(projectPath, scenario, () => {
       // Fetch new project info first before going to input editor
-      await fetchProject();
-      goToInputEditor();
+      fetchProject().then(() => {
+        goToInputEditor();
+      });
     });
   };
 };

--- a/src/renderer/components/Project/RenameScenarioModal.js
+++ b/src/renderer/components/Project/RenameScenarioModal.js
@@ -7,8 +7,8 @@ import { FormItemWrapper } from '../Tools/Parameter';
 import { useFetchProject } from './Project';
 
 const RenameScenarioModal = ({
-  scenario,
-  projectPath,
+  scenarioName,
+  project,
   visible,
   setVisible,
 }) => {
@@ -23,7 +23,7 @@ const RenameScenarioModal = ({
         console.log('Received values of form: ', values);
         try {
           const resp = await axios.put(
-            `http://localhost:5050/api/project/scenario/${scenario}`,
+            `http://localhost:5050/api/project/scenario/${scenarioName}`,
             values
           );
           console.log(resp.data);
@@ -52,17 +52,17 @@ const RenameScenarioModal = ({
       centered
       destroyOnClose
     >
-      <h2>Current Name: {scenario}</h2>
-      <RenameScenarioForm ref={formRef} projectPath={projectPath} />
+      <h2>Current Name: {scenarioName}</h2>
+      <RenameScenarioForm ref={formRef} project={project} />
     </Modal>
   );
 };
 
-const RenameScenarioForm = Form.create()(({ form, projectPath }) => {
-  const checkName = (projectPath, name) => {
+const RenameScenarioForm = Form.create()(({ form, project }) => {
+  const checkName = (project, name) => {
     const dirs = fs
-      .readdirSync(projectPath)
-      .filter((f) => fs.statSync(path.join(projectPath, f)).isDirectory());
+      .readdirSync(project)
+      .filter((f) => fs.statSync(path.join(project, f)).isDirectory());
     return dirs.includes(name);
   };
 
@@ -79,7 +79,7 @@ const RenameScenarioForm = Form.create()(({ form, projectPath }) => {
             validator: (rule, value, callback) => {
               if (
                 value.length != 0 &&
-                checkName(projectPath, form.getFieldValue('name'))
+                checkName(project, form.getFieldValue('name'))
               ) {
                 callback('Scenario with name already exists in the project');
               } else {

--- a/src/renderer/components/Project/RenameScenarioModal.js
+++ b/src/renderer/components/Project/RenameScenarioModal.js
@@ -1,11 +1,10 @@
 import React, { useState, useRef } from 'react';
-import { useDispatch } from 'react-redux';
 import { Modal, Form } from 'antd';
 import fs from 'fs';
 import path from 'path';
 import axios from 'axios';
-import { getProject } from '../../actions/project';
 import { FormItemWrapper } from '../Tools/Parameter';
+import { useFetchProject } from './Project';
 
 const RenameScenarioModal = ({
   scenario,
@@ -15,11 +14,7 @@ const RenameScenarioModal = ({
 }) => {
   const [confirmLoading, setConfirmLoading] = useState(false);
   const formRef = useRef();
-  const dispatch = useDispatch();
-
-  const reloadProject = () => {
-    dispatch(getProject());
-  };
+  const fetchProject = useFetchProject();
 
   const handleOk = (e) => {
     formRef.current.validateFields(async (err, values) => {
@@ -32,7 +27,7 @@ const RenameScenarioModal = ({
             values
           );
           console.log(resp.data);
-          reloadProject();
+          fetchProject();
           setVisible(false);
         } catch (err) {
           console.log(err.response);

--- a/src/renderer/components/Project/ScenarioCard.js
+++ b/src/renderer/components/Project/ScenarioCard.js
@@ -4,9 +4,9 @@ import axios from 'axios';
 import { deleteScenario, useOpenScenario, useFetchProject } from './Project';
 import RenameScenarioModal from './RenameScenarioModal';
 
-const ScenarioCard = ({ scenario, projectPath, active }) => {
-  const _openScenario = useOpenScenario();
-  const openScenario = () => _openScenario(projectPath, scenario);
+const ScenarioCard = ({ scenarioName, project, active }) => {
+  const openScenario = useOpenScenario();
+  const handleOpenScenario = () => openScenario(project, scenarioName);
 
   return (
     <Card
@@ -14,14 +14,14 @@ const ScenarioCard = ({ scenario, projectPath, active }) => {
       type="inner"
       title={
         <React.Fragment>
-          <span>{scenario} </span>
+          <span>{scenarioName} </span>
           {active && <Tag>Current</Tag>}
         </React.Fragment>
       }
       extra={
         <React.Fragment>
-          <EditScenarioMenu scenario={scenario} projectPath={projectPath} />
-          <Button type="primary" onClick={openScenario}>
+          <EditScenarioMenu scenarioName={scenarioName} project={project} />
+          <Button type="primary" onClick={handleOpenScenario}>
             Open
           </Button>
         </React.Fragment>
@@ -30,9 +30,9 @@ const ScenarioCard = ({ scenario, projectPath, active }) => {
       <Row>
         <Col span={6}>
           <ScenarioImage
-            projectPath={projectPath}
-            scenario={scenario}
-            onClick={openScenario}
+            project={project}
+            scenarioName={scenarioName}
+            onClick={handleOpenScenario}
           />
         </Col>
       </Row>
@@ -40,10 +40,10 @@ const ScenarioCard = ({ scenario, projectPath, active }) => {
   );
 };
 
-const ScenarioImage = ({ projectPath, scenario, onClick = () => {} }) => {
+const ScenarioImage = ({ project, scenarioName, onClick = () => {} }) => {
   const [image, isLoading, error] = useGenerateScenarioImage(
-    projectPath,
-    scenario
+    project,
+    scenarioName
   );
 
   return (
@@ -71,7 +71,7 @@ const ScenarioImage = ({ projectPath, scenario, onClick = () => {} }) => {
   );
 };
 
-const useGenerateScenarioImage = (projectPath, scenario) => {
+const useGenerateScenarioImage = (project, scenarioName) => {
   const [data, setData] = useState({ image: null });
   const [isLoading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -80,8 +80,8 @@ const useGenerateScenarioImage = (projectPath, scenario) => {
     const fetch = async () => {
       try {
         const resp = await axios.get(
-          `http://localhost:5050/api/project/scenario/${scenario}/image`,
-          { params: { projectPath: projectPath } }
+          `http://localhost:5050/api/project/scenario/${scenarioName}/image`,
+          { params: { project } }
         );
         setData(resp.data);
       } catch (err) {
@@ -97,7 +97,7 @@ const useGenerateScenarioImage = (projectPath, scenario) => {
   return [data.image, isLoading, error];
 };
 
-const EditScenarioMenu = ({ scenario, projectPath }) => {
+const EditScenarioMenu = ({ scenarioName, project }) => {
   const [isModalVisible, setModalVisible] = useState(false);
   const fetchProject = useFetchProject();
 
@@ -108,7 +108,7 @@ const EditScenarioMenu = ({ scenario, projectPath }) => {
       content: (
         <div>
           <p>
-            <b>{scenario}</b>
+            <b>{scenarioName}</b>
           </p>
           <p>
             <i>(This operation cannot be reversed)</i>
@@ -119,7 +119,7 @@ const EditScenarioMenu = ({ scenario, projectPath }) => {
       okType: 'danger',
       okButtonProps: { disabled: true },
       cancelText: 'Cancel',
-      onOk: () => deleteScenario(scenario, () => fetchProject()),
+      onOk: () => deleteScenario(scenarioName, fetchProject),
       centered: true,
     });
 
@@ -139,7 +139,7 @@ const EditScenarioMenu = ({ scenario, projectPath }) => {
   };
 
   return (
-    <span id={`${scenario}-edit-button`} className="scenario-edit-button">
+    <span id={`${scenarioName}-edit-button`} className="scenario-edit-button">
       <Dropdown
         overlay={
           <Menu>
@@ -158,7 +158,7 @@ const EditScenarioMenu = ({ scenario, projectPath }) => {
         }
         trigger={['click']}
         getPopupContainer={() => {
-          return document.getElementById(`${scenario}-edit-button`);
+          return document.getElementById(`${scenarioName}-edit-button`);
         }}
       >
         <Button>
@@ -166,8 +166,8 @@ const EditScenarioMenu = ({ scenario, projectPath }) => {
         </Button>
       </Dropdown>
       <RenameScenarioModal
-        scenario={scenario}
-        projectPath={projectPath}
+        scenarioName={scenarioName}
+        project={project}
         visible={isModalVisible}
         setVisible={setModalVisible}
       />

--- a/src/renderer/components/Project/ScenarioCard.js
+++ b/src/renderer/components/Project/ScenarioCard.js
@@ -6,7 +6,7 @@ import RenameScenarioModal from './RenameScenarioModal';
 
 const ScenarioCard = ({ scenario, projectPath, active }) => {
   const _openScenario = useOpenScenario();
-  const openScenario = () => _openScenario(scenario);
+  const openScenario = () => _openScenario(projectPath, scenario);
 
   return (
     <Card

--- a/src/renderer/reducers/project.js
+++ b/src/renderer/reducers/project.js
@@ -6,7 +6,12 @@ import {
 } from '../actions/project';
 
 const initialState = {
-  info: { name: null, path: null, scenario: null, scenarios: [] },
+  info: {
+    project: null,
+    project_name: null,
+    scenario_name: null,
+    scenarios_list: [],
+  },
   isFetching: false,
   error: null,
 };

--- a/src/renderer/reducers/project.js
+++ b/src/renderer/reducers/project.js
@@ -2,6 +2,7 @@ import {
   GET_PROJECT,
   GET_PROJECT_FAILED,
   GET_PROJECT_SUCCESS,
+  UPDATE_SCENARIO,
 } from '../actions/project';
 
 const initialState = {
@@ -18,6 +19,8 @@ const project = (state = initialState, { type, payload }) => {
       return { ...state, ...payload };
     case GET_PROJECT_FAILED:
       return { ...state, ...initialState, ...payload };
+    case UPDATE_SCENARIO:
+      return { ...state, info: { ...state.info, ...payload } };
     default:
       return state;
   }

--- a/src/renderer/reducers/project.js
+++ b/src/renderer/reducers/project.js
@@ -5,7 +5,7 @@ import {
 } from '../actions/project';
 
 const initialState = {
-  info: { name: '', path: '', scenario: '', scenarios: [] },
+  info: { name: null, path: null, scenario: null, scenarios: [] },
   isFetching: false,
   error: null,
 };


### PR DESCRIPTION
This PR is to be used with https://github.com/architecture-building-systems/CityEnergyAnalyst/pull/2754 to test project functions. With this, GUI does not save project details (i.e. project path and scenario name) to config when opening/creating projects, only when opening/creating a scenario.