### PR TITLE
Fix for importing files when creating new scenario

### DIFF
--- a/src/renderer/components/Map/EditableMap.js
+++ b/src/renderer/components/Map/EditableMap.js
@@ -154,6 +154,7 @@ const EditableMap = ({
         controller={{ doubleClickZoom: false, dragRotate: false }}
         layers={[layer]}
         onViewStateChange={onViewStateChange}
+        useDevicePixels={false}
       >
         <ReactMapGL
           mapStyle={mapStyles.LIGHT_MAP}

--- a/src/renderer/components/Project/ScenarioGenerateDataForm.js
+++ b/src/renderer/components/Project/ScenarioGenerateDataForm.js
@@ -172,9 +172,10 @@ const checkLatLong = (rule, value, callback) => {
 };
 
 const checkArea = (rule, value, callback) => {
-  if (rule.required && !value)
+  if (!rule.required) callback();
+  else if (!value)
     callback('Create a polygon by selecting an area in the map.');
-  if (calcPolyArea(value) > MAX_AREA_SIZE) {
+  else if (calcPolyArea(value) > MAX_AREA_SIZE) {
     callback(
       `Area selected is above ${MAX_AREA_SIZE} km2. CEA would not be able to extract information from that size due to the bandwidth limitation of Open Street Maps API. Try selecting a smaller area.`
     );


### PR DESCRIPTION
This includes fix for https://github.com/architecture-building-systems/CityEnergyAnalyst/issues/2753 where users were not able to import their own files when creating a new scenario due to error callback from a form field preventing the form to be submitted.

This also includes a small fix where the map would crash in high dpi screens.