### PR TITLE
Fix choices not appearing as dropdown when editing multiple selections in input editor

### DIFF
--- a/src/renderer/components/InputEditor/EditSelectedModal.js
+++ b/src/renderer/components/InputEditor/EditSelectedModal.js
@@ -107,7 +107,7 @@ const InputDataForm = Form.create()(({ form, inputTable, table }) => {
 const createFormItem = (form, title, columnInfo) => {
   const { type, choices, constraints } = columnInfo;
 
-  if (type == 'choice') {
+  if (typeof choices !== 'undefined') {
     const Options = choices.map(({ value, label }) => (
       <Select.Option key={value} value={value}>
         {`${value} : ${label}`}


### PR DESCRIPTION
This PR fixes https://github.com/architecture-building-systems/CityEnergyAnalyst/issues/2808

This issue is caused by a bug in the logic when trying to create dropdown selection for columns that support choices.
Such columns have an extra property called `choices` instead of their type as "choice", therefore it should be checking for the property instead of the value of `type`.