### PR TITLE
Fix route redirection for project creation

### DIFF
--- a/src/components/Landing/Buttons/NewProjectModalButton.jsx
+++ b/src/components/Landing/Buttons/NewProjectModalButton.jsx
@@ -12,7 +12,7 @@ const NewProjectModalButton = () => {
   const dispatch = useDispatch();
 
   const goToProjectPage = () => {
-    dispatch(push(routes.PROJECT_OVERVIEW));
+    dispatch(push(routes.PROJECT));
   };
 
   return (


### PR DESCRIPTION
Creating a new Project is redirecting to an old route which is obsolete in version 4.