### PR TITLE
Check internet using cityenergyanalyst.com instead of google.com

### DIFF
--- a/electron/utils.mjs
+++ b/electron/utils.mjs
@@ -2,7 +2,7 @@ import dns from 'dns';
 
 export async function checkInternet() {
   try {
-    await dns.promises.lookup('google.com');
+    await dns.promises.lookup('www.cityenergyanalyst.com');
     return true; // Internet is connected
   } catch (err) {
     if (err.code === 'ENOTFOUND') {


### PR DESCRIPTION
Using google.com could cause some issues with some users in places where is google is blocked, where the GUI would not launch.