### PR TITLE
Fix weather-helper input parameter not accepting user input

### DIFF
--- a/src/components/Tools/Parameter.jsx
+++ b/src/components/Tools/Parameter.jsx
@@ -222,7 +222,12 @@ const Parameter = ({ parameter, form }) => {
                 <div>
                   {menu}
                   <Divider style={{ margin: '4px 0' }} />
-                  <OpenDialogButton form={form} type="directory" id={name}>
+                  <OpenDialogButton
+                    form={form}
+                    type="directory"
+                    id={name}
+                    onChange={(value) => setFieldsValue({ [name]: value })}
+                  >
                     <PlusOutlined />
                     Browse for databases path
                   </OpenDialogButton>
@@ -255,6 +260,7 @@ const Parameter = ({ parameter, form }) => {
                     type="file"
                     filters={[{ name: 'Weather files', extensions: ['epw'] }]}
                     id={name}
+                    onChange={(value) => setFieldsValue({ [name]: value })}
                   >
                     <PlusOutlined />
                     Browse for weather file


### PR DESCRIPTION
Set value during onChange event to solve the following error:
"Warning: You cannot set a form field before rendering a field associated with the value."