### PR TITLE
Update map to consider void decks

### DIFF
--- a/src/components/Map/Map.jsx
+++ b/src/components/Map/Map.jsx
@@ -352,6 +352,8 @@ const DeckGLMap = ({ data, tables, colors }) => {
   }, [cameraOptionsCalulated, data?.zone, mapRef]);
 
   const dataLayers = useMemo(() => {
+    const envelopeTable = tables?.envelope;
+
     const onClick = ({ object, layer }, event) => {
       const name = object.properties[INDEX_COLUMN];
       if (layer.id !== selectedLayer) {
@@ -380,7 +382,6 @@ const DeckGLMap = ({ data, tables, colors }) => {
 
     let _layers = [];
     if (data?.zone) {
-      const envelopeTable = tables?.envelope;
       _layers.push(
         new PolygonLayer({
           id: 'zone',
@@ -408,7 +409,7 @@ const DeckGLMap = ({ data, tables, colors }) => {
           autoHighlight: true,
           highlightColor: [255, 255, 0, 128],
 
-          onHover: updateTooltip,
+          onHover: (f) => updateTooltip(f, envelopeTable),
           onClick: onClick,
         }),
       );
@@ -439,7 +440,7 @@ const DeckGLMap = ({ data, tables, colors }) => {
           autoHighlight: true,
           highlightColor: [255, 255, 0, 128],
 
-          onHover: updateTooltip,
+          onHover: (f) => updateTooltip(f, envelopeTable),
           onClick: onClick,
         }),
       );
@@ -492,7 +493,16 @@ const DeckGLMap = ({ data, tables, colors }) => {
     }
 
     return _layers;
-  }, [visibility, data, selectedLayer, selected, extruded, buildingColor]);
+  }, [
+    visibility,
+    data,
+    selectedLayer,
+    selected,
+    extruded,
+    buildingColor,
+    tables?.envelope,
+    setSelected,
+  ]);
 
   const mapLayers = useMapLayers();
 
@@ -541,7 +551,8 @@ const DeckGLMap = ({ data, tables, colors }) => {
   );
 };
 
-function updateTooltip({ x, y, object, layer }) {
+function updateTooltip(feature, envelopeTable) {
+  const { x, y, object, layer } = feature;
   const tooltip = document.getElementById('map-tooltip');
   if (object) {
     const { properties } = object;
@@ -565,7 +576,7 @@ function updateTooltip({ x, y, object, layer }) {
           Math.round(
             (properties?.floors_ag +
               properties?.floors_bg -
-              properties?.void_deck) *
+              envelopeTable?.[properties?.[INDEX_COLUMN]]?.void_deck ?? 0) *
               area *
               1000,
           ) / 1000

--- a/src/components/Map/Map.jsx
+++ b/src/components/Map/Map.jsx
@@ -617,7 +617,7 @@ const VOID_DECK_FLOOR_HEIGHT = 3;
 
 const calcPolygonWithZ = (feature, envelopeTable) => {
   const name = feature?.properties?.[INDEX_COLUMN];
-  const coords = feature.geometry.coordinates;
+  const coords = feature?.geometry?.coordinates ?? [];
 
   if (name === null) return coords;
 

--- a/src/components/Map/Map.jsx
+++ b/src/components/Map/Map.jsx
@@ -616,7 +616,7 @@ const buildingColorFunction = (colors, selected) => (buildingName, layer) => {
 const VOID_DECK_FLOOR_HEIGHT = 3;
 
 const calcPolygonWithZ = (feature, envelopeTable) => {
-  const name = feature?.properties?.name;
+  const name = feature?.properties?.[INDEX_COLUMN];
   const coords = feature.geometry.coordinates;
 
   if (name === null) return coords;
@@ -628,7 +628,7 @@ const calcPolygonWithZ = (feature, envelopeTable) => {
 };
 
 const calcPolygonElevation = (feature, envelopeTable) => {
-  const name = feature?.properties?.name;
+  const name = feature?.properties?.[INDEX_COLUMN];
   const height_ag = feature?.properties?.height_ag ?? 0;
 
   if (name === null) return height_ag;

--- a/src/components/Map/Map.jsx
+++ b/src/components/Map/Map.jsx
@@ -558,8 +558,13 @@ function updateTooltip({ x, y, object, layer }) {
       innerHTML += `<br><div><b>Floor Area</b>: ${area}m<sup>2</sup></div>`;
       if (layer.id === 'zone')
         innerHTML += `<div><b>GFA</b>: ${
+          // Remove void_deck from GFA calculation
           Math.round(
-            (properties['floors_ag'] + properties['floors_bg']) * area * 1000,
+            (properties?.floors_ag +
+              properties?.floors_bg -
+              properties?.void_deck) *
+              area *
+              1000,
           ) / 1000
         }m<sup>2</sup></div>`;
     } else if (layer.id === 'dc' || layer.id === 'dh') {

--- a/src/components/Map/Map.jsx
+++ b/src/components/Map/Map.jsx
@@ -574,9 +574,9 @@ function updateTooltip(feature, envelopeTable) {
         innerHTML += `<div><b>GFA</b>: ${
           // Remove void_deck from GFA calculation
           Math.round(
-            (properties?.floors_ag +
-              properties?.floors_bg -
-              envelopeTable?.[properties?.[INDEX_COLUMN]]?.void_deck ?? 0) *
+            ((properties?.floors_ag ?? 0) +
+              (properties?.floors_bg ?? 0) -
+              (envelopeTable?.[properties?.[INDEX_COLUMN]]?.void_deck ?? 0)) *
               area *
               1000,
           ) / 1000

--- a/src/containers/Project.jsx
+++ b/src/containers/Project.jsx
@@ -317,7 +317,7 @@ const ProjectOverlay = ({ project, scenarioName }) => {
 
 const InputMap = ({ project, scenario }) => {
   const { data, refetch, isFetching, isError, error } = useInputs();
-  const { geojsons, colors } = data;
+  const { tables, geojsons, colors } = data;
 
   const [messageApi, contextHolder] = message.useMessage();
   const onError = (error) => {
@@ -370,7 +370,7 @@ const InputMap = ({ project, scenario }) => {
             fullscreen
           />
         )}
-        <DeckGLMap data={geojsons} colors={colors} />
+        <DeckGLMap data={geojsons} tables={tables} colors={colors} />
       </div>
     </>
   );


### PR DESCRIPTION
This is related to the PR https://github.com/architecture-building-systems/CityEnergyAnalyst/pull/3850, that considers void deck for the building geometry.

- Void deck floors will not be included in the GFA calculations in the hovering tooltip
- Building geometry footprints will be raised to ignore void deck floors, and overall height of the polygon is adjusted accordingly in the map.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved 3D rendering of zone polygons on the map by accurately accounting for void deck floors in both geometry and elevation.
  * Enhanced tooltip calculations to reflect Gross Floor Area (GFA) adjustments based on void deck floor counts.
  * Added support for additional data tables to enrich map visualizations and interactions.

* **Bug Fixes**
  * Tooltips now display correct GFA values by subtracting void deck floors from total floor counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->