### PR TITLE
Fix tool description height after loading

### DIFF
--- a/src/features/project/components/Cards/ToolCardSideButtons.jsx
+++ b/src/features/project/components/Cards/ToolCardSideButtons.jsx
@@ -7,10 +7,13 @@ import {
   useSetToolType,
   useToolType,
 } from 'features/project/stores/tool-card';
+import { useSelectedToolStore } from 'features/tools/stores/selected-tool';
 
 export const ToolCardSideButtons = () => {
   const toolType = useToolType();
   const setToolType = useSetToolType();
+
+  const selectedTool = useSelectedToolStore((state) => state.selectedTool);
 
   const closeToolCard = useCloseToolCard();
 
@@ -29,16 +32,18 @@ export const ToolCardSideButtons = () => {
         gap: 8,
       }}
     >
-      <Button
-        onClick={() =>
-          toolType !== toolTypes.TOOLS
-            ? setToolType(toolTypes.TOOLS)
-            : closeToolCard()
-        }
-        type={toolType === toolTypes.TOOLS ? 'primary' : 'default'}
-      >
-        Tools
-      </Button>
+      {selectedTool != null && (
+        <Button
+          onClick={() =>
+            toolType !== toolTypes.TOOLS
+              ? setToolType(toolTypes.TOOLS)
+              : closeToolCard()
+          }
+          type={toolType === toolTypes.TOOLS ? 'primary' : 'default'}
+        >
+          Tools
+        </Button>
+      )}
       <Button
         onClick={() =>
           toolType !== toolTypes.BUILDING_INFO

--- a/src/features/tools/components/Tools/Tool.jsx
+++ b/src/features/tools/components/Tools/Tool.jsx
@@ -224,18 +224,28 @@ const Tool = ({ script, onToolSelected, header }) => {
   const disableButtons = fetching || _error !== null;
 
   const [headerVisible, setHeaderVisible] = useState(true);
+  const [showSkeleton, setShowSkeleton] = useState(true);
   const lastScrollPositionRef = useRef(0);
 
   const descriptionRef = useRef(null);
   const descriptionHeightRef = useRef('auto');
 
+  // Hide skeleton after grid transition completes
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setShowSkeleton(false);
+    }, 350); // 50ms buffer after 300ms transition
+
+    return () => clearTimeout(timer);
+  }, []);
+
   // This effect will measure the actual height of the description
   useLayoutEffect(() => {
-    if (descriptionRef.current) {
+    if (descriptionRef.current && !showSkeleton) {
       const height = descriptionRef.current.scrollHeight;
       descriptionHeightRef.current = height;
     }
-  }, [description, descriptionRef.current]);
+  }, [description, showSkeleton]);
 
   const handleScroll = useCallback((e) => {
     // Ensure the scroll threshold greater than the description height to prevent layout shifts
@@ -283,7 +293,7 @@ const Tool = ({ script, onToolSelected, header }) => {
     return () => resetToolParams();
   }, [script, fetchToolParams, resetToolParams]);
 
-  if (status == 'fetching')
+  if (status == 'fetching' || showSkeleton)
     return (
       <div style={{ padding: 12 }}>
         {header}

--- a/src/features/tools/components/Tools/Tool.jsx
+++ b/src/features/tools/components/Tools/Tool.jsx
@@ -5,7 +5,7 @@ import {
   useLayoutEffect,
   useCallback,
 } from 'react';
-import { Skeleton, Divider, Spin, Alert, Form } from 'antd';
+import { Divider, Spin, Alert, Form } from 'antd';
 import useToolsStore from 'features/tools/stores/toolsStore';
 import useJobsStore from 'features/jobs/stores/jobsStore';
 import { AsyncError } from 'components/AsyncError';
@@ -19,6 +19,7 @@ import { useSetShowLoginModal } from 'features/auth/stores/login-modal';
 import ToolForm, { ToolFormButtons } from './ToolForm';
 import { ToolDescription } from 'features/tools/components/tool-description';
 import { useChangesExist } from 'features/input-editor/stores/inputEditorStore';
+import { ToolSkeleton } from '../tool-skeleton';
 
 const useCheckMissingInputs = (tool) => {
   const [fetching, setFetching] = useState(false);
@@ -297,16 +298,7 @@ const Tool = ({ script, onToolSelected, header }) => {
     return (
       <div style={{ padding: 12 }}>
         {header}
-        <Skeleton active />
-        <div className="cea-tool-form-buttongroup">
-          <Skeleton.Button active />
-          <Skeleton.Button active />
-          <Skeleton.Button active />
-        </div>
-        <Divider />
-        <Skeleton active />
-        <Skeleton active />
-        <Skeleton active />
+        <ToolSkeleton loadingText="Loading parameters..." />
       </div>
     );
   if (status == 'failed')

--- a/src/features/tools/components/tool-skeleton.jsx
+++ b/src/features/tools/components/tool-skeleton.jsx
@@ -1,0 +1,42 @@
+import { LoadingOutlined } from '@ant-design/icons';
+import { Skeleton, Divider, Spin } from 'antd';
+
+export const ToolSkeleton = ({ loadingText = 'Loading...' }) => {
+  return (
+    <div style={{ position: 'relative' }}>
+      <div
+        style={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+
+          alignItems: 'center',
+          justifyContent: 'center',
+
+          gap: 12,
+
+          backdropFilter: 'blur(1px)',
+        }}
+      >
+        <Spin indicator={<LoadingOutlined spin />} size="large" />
+        {loadingText}
+      </div>
+      <Skeleton active />
+      <div className="cea-tool-form-buttongroup">
+        <Skeleton.Button active />
+        <Skeleton.Button active />
+        <Skeleton.Button active />
+      </div>
+      <Divider />
+      <Skeleton active />
+      <Skeleton active />
+      <Skeleton active />
+    </div>
+  );
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a custom loading skeleton for tool interfaces, providing a visually enhanced loading experience.
* **Improvements**
  * The loading skeleton now appears with a short delay to ensure smoother grid transitions.
  * The "Tools" button is now only displayed when a tool is selected, resulting in a more streamlined interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->