### PR TITLE
Expand accepted zip file MIME types in upload

### DIFF
--- a/src/features/upload-download/components/UploadForm.jsx
+++ b/src/features/upload-download/components/UploadForm.jsx
@@ -340,7 +340,14 @@ const FileUploadBox = ({ onChange, onFinish, onRemove, fileList, status }) => {
   const beforeUpload = async (file) => {
     // Do basic checks first
     try {
-      if (file.type !== 'application/zip') {
+      const validZipTypes = [
+        'application/zip',
+        'application/x-zip-compressed',
+        'application/octet-stream',
+      ];
+      const isValidZip = validZipTypes.includes(file.type);
+
+      if (!isValidZip && !file.name.toLowerCase().endsWith('.zip')) {
         throw new Error('File type must be .zip');
       }
 


### PR DESCRIPTION
The file upload validation now accepts additional MIME types for zip files, including 'application/x-zip-compressed' and 'application/octet-stream', and also checks the file extension. This helps fix upload problems on Microsoft Edge browsers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved ZIP upload compatibility across browsers. The upload form now recognizes multiple ZIP MIME types and also accepts files by the .zip extension, reducing false rejections of valid archives. No changes to size limits or processing behavior. Users should see fewer errors when dragging or selecting ZIP files from different operating systems and tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->