### PR TITLE
Add building name labels on map

### DIFF
--- a/src/features/map/components/Map/LayerToggle.jsx
+++ b/src/features/map/components/Map/LayerToggle.jsx
@@ -70,10 +70,9 @@ const LayerToggleRadio = ({ label, value, onChange }) => {
 };
 
 const generateLayerToggle = (data, handleChange, handleMapLabelsChange) => {
-  const out = [];
-
+  const geometryGroup = [];
   if (data?.zone) {
-    out.push({
+    geometryGroup.push({
       label: (
         <LayerToggleRadio
           label="Zone"
@@ -83,20 +82,10 @@ const generateLayerToggle = (data, handleChange, handleMapLabelsChange) => {
         />
       ),
     });
-    out.push({
-      label: (
-        <LayerToggleRadio
-          label="Zone Labels"
-          value="zone_labels"
-          onChange={handleChange}
-          checked
-        />
-      ),
-    });
   }
 
   if (data?.surroundings) {
-    out.push({
+    geometryGroup.push({
       label: (
         <LayerToggleRadio
           label="Surroundings"
@@ -108,7 +97,7 @@ const generateLayerToggle = (data, handleChange, handleMapLabelsChange) => {
   }
 
   if (data?.trees) {
-    out.push({
+    geometryGroup.push({
       label: (
         <LayerToggleRadio label="Trees" value="trees" onChange={handleChange} />
       ),
@@ -116,7 +105,7 @@ const generateLayerToggle = (data, handleChange, handleMapLabelsChange) => {
   }
 
   if (data?.streets) {
-    out.push({
+    geometryGroup.push({
       label: (
         <LayerToggleRadio
           label="Streets"
@@ -128,7 +117,7 @@ const generateLayerToggle = (data, handleChange, handleMapLabelsChange) => {
   }
 
   if (data?.dh || data?.dc) {
-    out.push({
+    geometryGroup.push({
       label: (
         <LayerToggleRadio
           label="Network"
@@ -138,14 +127,31 @@ const generateLayerToggle = (data, handleChange, handleMapLabelsChange) => {
       ),
     });
   }
-  if (out.length > 0) out.unshift({ type: 'group', label: 'Data' });
+  if (geometryGroup.length > 0)
+    geometryGroup.unshift({ type: 'group', label: 'Geometry' });
 
-  out.push({
+  const labelsGroup = [];
+  if (data?.zone) {
+    labelsGroup.push({ type: 'group', label: 'Labels' });
+    labelsGroup.push({
+      label: (
+        <LayerToggleRadio
+          label="Building Names"
+          value="zone_labels"
+          onChange={handleChange}
+          checked
+        />
+      ),
+    });
+  }
+
+  const mapStyleGroup = [];
+  mapStyleGroup.push({
     type: 'group',
     label: 'Map Style',
   });
 
-  out.push({
+  mapStyleGroup.push({
     key: 'map_labels',
     label: (
       <LayerToggleRadio
@@ -156,7 +162,7 @@ const generateLayerToggle = (data, handleChange, handleMapLabelsChange) => {
     ),
   });
 
-  return out;
+  return [...geometryGroup, ...labelsGroup, ...mapStyleGroup];
 };
 
 const LayerToggle = () => {

--- a/src/features/map/components/Map/LayerToggle.jsx
+++ b/src/features/map/components/Map/LayerToggle.jsx
@@ -83,6 +83,16 @@ const generateLayerToggle = (data, handleChange, handleMapLabelsChange) => {
         />
       ),
     });
+    out.push({
+      label: (
+        <LayerToggleRadio
+          label="Zone Labels"
+          value="zone_labels"
+          onChange={handleChange}
+          checked
+        />
+      ),
+    });
   }
 
   if (data?.surroundings) {

--- a/src/features/map/components/Map/Map.css
+++ b/src/features/map/components/Map/Map.css
@@ -64,11 +64,10 @@
   padding-inline: 8px;
 }
 
-.tooltip-building-details {
+.tooltip-content {
   display: flex;
+  flex-direction: column;
   gap: 12px;
-  margin-block: 12px;
-  min-width: max-content;
 }
 
 .tooltip-section-title {

--- a/src/features/map/components/Map/Map.css
+++ b/src/features/map/components/Map/Map.css
@@ -1,28 +1,3 @@
-#map-tooltip:empty {
-  display: none;
-}
-#map-tooltip {
-  font-family:
-    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
-    Arial, sans-serif;
-  font-size: 12px;
-  position: absolute;
-  padding: 8px 12px;
-  margin: 8px;
-  background: rgba(20, 20, 30, 0.8);
-  backdrop-filter: blur(2px);
-  color: #fff;
-  max-width: 320px;
-  z-index: 9;
-  pointer-events: none;
-  user-select: none;
-  border-radius: 8px;
-  box-shadow:
-    0 4px 12px rgba(0, 0, 0, 0.4),
-    0 0 0 1px rgba(255, 255, 255, 0.1);
-  line-height: 1.5;
-}
-
 .network-toggle {
   position: absolute;
   z-index: 5;
@@ -62,21 +37,4 @@
   align-items: center;
 
   padding-inline: 8px;
-}
-
-.tooltip-content {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.tooltip-section-title {
-  font-weight: bold;
-  margin-bottom: 4px;
-}
-
-.tooltip-grid {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  gap: 2px 12px;
 }

--- a/src/features/map/components/Map/Map.css
+++ b/src/features/map/components/Map/Map.css
@@ -68,6 +68,7 @@
   display: flex;
   gap: 12px;
   margin-block: 12px;
+  min-width: max-content;
 }
 
 .tooltip-section-title {

--- a/src/features/map/components/Map/Map.css
+++ b/src/features/map/components/Map/Map.css
@@ -9,7 +9,7 @@
   position: absolute;
   padding: 12px 14px;
   margin: 8px;
-  background: rgba(20, 20, 30, 0.8);
+  background: rgba(20, 20, 30, 0.6);
   backdrop-filter: blur(8px);
   color: #fff;
   max-width: 320px;
@@ -28,7 +28,7 @@
 }
 
 #map-tooltip b {
-  color: #94a3b8;
+  color: #d5d5d5;
   font-weight: 500;
   margin-right: 4px;
 }

--- a/src/features/map/components/Map/Map.css
+++ b/src/features/map/components/Map/Map.css
@@ -2,18 +2,35 @@
   display: none;
 }
 #map-tooltip {
-  font-family: Helvetica, Arial, sans-serif;
-  font-size: 11px;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
+    Arial, sans-serif;
+  font-size: 12px;
   position: absolute;
-  padding: 4px;
+  padding: 12px 14px;
   margin: 8px;
-  background: rgba(0, 0, 0, 0.8);
+  background: rgba(20, 20, 30, 0.8);
+  backdrop-filter: blur(8px);
   color: #fff;
-  max-width: 300px;
-  font-size: 10px;
+  max-width: 320px;
   z-index: 9;
   pointer-events: none;
   user-select: none;
+  border-radius: 8px;
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(255, 255, 255, 0.1);
+  line-height: 1.5;
+}
+
+#map-tooltip div {
+  margin: 2px 0;
+}
+
+#map-tooltip b {
+  color: #94a3b8;
+  font-weight: 500;
+  margin-right: 4px;
 }
 
 .network-toggle {

--- a/src/features/map/components/Map/Map.css
+++ b/src/features/map/components/Map/Map.css
@@ -23,10 +23,6 @@
   line-height: 1.5;
 }
 
-#map-tooltip div {
-  margin: 2px 0;
-}
-
 .network-toggle {
   position: absolute;
   z-index: 5;
@@ -66,4 +62,26 @@
   align-items: center;
 
   padding-inline: 8px;
+}
+
+.tooltip-building-details {
+  display: flex;
+  gap: 12px;
+  margin-block: 12px;
+}
+
+.tooltip-section-title {
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+
+.tooltip-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 12px;
+}
+
+.tooltip-value-above-ground,
+.tooltip-value-below-ground {
+  font-weight: bold;
 }

--- a/src/features/map/components/Map/Map.css
+++ b/src/features/map/components/Map/Map.css
@@ -80,8 +80,3 @@
   grid-template-columns: auto 1fr;
   gap: 2px 12px;
 }
-
-.tooltip-value-above-ground,
-.tooltip-value-below-ground {
-  font-weight: bold;
-}

--- a/src/features/map/components/Map/Map.css
+++ b/src/features/map/components/Map/Map.css
@@ -7,10 +7,10 @@
     Arial, sans-serif;
   font-size: 12px;
   position: absolute;
-  padding: 12px 14px;
+  padding: 8px 12px;
   margin: 8px;
-  background: rgba(20, 20, 30, 0.6);
-  backdrop-filter: blur(8px);
+  background: rgba(20, 20, 30, 0.8);
+  backdrop-filter: blur(2px);
   color: #fff;
   max-width: 320px;
   z-index: 9;
@@ -25,12 +25,6 @@
 
 #map-tooltip div {
   margin: 2px 0;
-}
-
-#map-tooltip b {
-  color: #d5d5d5;
-  font-weight: 500;
-  margin-right: 4px;
 }
 
 .network-toggle {

--- a/src/features/map/components/Map/Map.jsx
+++ b/src/features/map/components/Map/Map.jsx
@@ -704,9 +704,11 @@ function updateTooltip(feature) {
           const ratio = properties?.[`use_type${i}r`];
 
           if (usetype && usetype !== 'NONE' && ratio && ratio > 0) {
-            innerHTML += `<div><b>${i}</b>: ${usetype} <b>(${
-              Math.round(ratio * 1000) / 10
-            }%)</b></div>`;
+            innerHTML += `
+            <div class="tooltip-grid">
+              <div>${i}: <span style="font-family: 'Space Grotesk', sans-serif">${usetype}</span></div>
+              <b style="margin-left: auto;">(${Math.round(ratio * 1000) / 10}%)</b>
+            </div>`;
           }
         }
       }

--- a/src/features/map/components/Map/Map.jsx
+++ b/src/features/map/components/Map/Map.jsx
@@ -647,7 +647,7 @@ function updateTooltip(feature) {
     const isZone = layer.id === 'zone';
 
     if (isZone || layer.id === 'surroundings') {
-      innerHTML += `<div><b>Name</b>: ${properties[INDEX_COLUMN]}</div>`;
+      innerHTML += `<div style="font-weight: bold; margin-bottom: 4px;">${properties[INDEX_COLUMN]}</div>`;
 
       if (properties?.year) {
         innerHTML += `<div><b>Year</b>: ${properties.year}</div>`;
@@ -661,31 +661,34 @@ function updateTooltip(feature) {
       const voidDeck = properties?.void_deck ?? 0;
 
       innerHTML += `
-        <div style="display: flex; align-items: flex-start; gap: 12px; margin-block: 8px;">
-          <div style="flex: 1;">
-            <div style="margin-bottom: 8px;">
-              <div style="font-weight: bold; margin-bottom: 2px;">Above Ground</div>
-              <div>• Height: ${heightAg}m</div>
-              <div>• Floors: ${floorsAg} ${voidDeck > 0 ? `(with ${voidDeck} void decks)` : ''}</div>
+        <div class="tooltip-building-details">
+          <div class="tooltip-section">
+            <div class="tooltip-section-title">Above Ground</div>
+            <div class="tooltip-grid">
+              <div>Height</div><div><span class="tooltip-value-above-ground">${heightAg} m</span></div>
+              <div>Floors</div><div><span class="tooltip-value-above-ground">${floorsAg}</span></div>
+              ${isZone ? `<div>Void deck</div><div><span class="tooltip-value-above-ground">${voidDeck}</span></div>` : ''}
             </div>
-            ${
-              isZone
-                ? `<div>
-              <div style="font-weight: bold; margin-bottom: 2px;">Below Ground</div>
-              <div>• Depth: ${heightBg}m</div>
-              <div>• Floors: ${floorsBg}</div>
-            </div>`
-                : ''
-            }
           </div>
+          ${
+            isZone
+              ? `<div class="tooltip-section">
+            <div class="tooltip-section-title">Below Ground</div>
+            <div class="tooltip-grid">
+              <div>Depth</div><div><span class="tooltip-value-below-ground">${heightBg} m</span></div>
+              <div>Floors</div><div><span class="tooltip-value-below-ground">${floorsBg}</span></div>
+            </div>
+          </div>`
+              : ''
+          }
         </div>`;
 
       let area = Math.round(turf.area(object) * 1000) / 1000;
-      innerHTML += `<div><b>Floor Area</b>: ${area}m<sup>2</sup></div>`;
+      innerHTML += `<div><b>Floor Area</b>: ${area} m<sup>2</sup></div>`;
       if (isZone) {
         const gfa = Math.max(0, (floorsAg + floorsBg - voidDeck) * area);
 
-        innerHTML += `<div><b>GFA</b>: ${Math.round(gfa * 1000) / 1000}m<sup>2</sup></div>`;
+        innerHTML += `<div><b>GFA</b>: ${Math.round(gfa * 1000) / 1000} m<sup>2</sup></div>`;
 
         innerHTML += '<br/><div><b>Use Types</b></div>';
         for (let i = 1; i < 4; i++) {
@@ -693,9 +696,9 @@ function updateTooltip(feature) {
           const ratio = properties?.[`use_type${i}r`];
 
           if (usetype && usetype !== 'NONE' && ratio && ratio > 0) {
-            innerHTML += `<div><b>${i}</b>: ${usetype} (${
+            innerHTML += `<div><b>${i}</b>: ${usetype} <b>(${
               Math.round(ratio * 1000) / 10
-            }%)</div>`;
+            }%)</b></div>`;
           }
         }
       }

--- a/src/features/map/components/Map/Map.jsx
+++ b/src/features/map/components/Map/Map.jsx
@@ -644,20 +644,45 @@ function updateTooltip(feature) {
     const { properties } = object;
     let innerHTML = '';
 
-    if (layer.id === 'zone' || layer.id === 'surroundings') {
-      innerHTML += `<div><b>Name</b>: ${properties[INDEX_COLUMN]}</div><br />`;
-      Object.keys(properties).forEach((key) => {
-        if (key === INDEX_COLUMN) return;
-        if (zoneLabels.includes(key))
-          innerHTML += `<div><b>${key}</b>: ${properties[key]}</div>`;
-      });
+    const isZone = layer.id === 'zone';
+
+    if (isZone || layer.id === 'surroundings') {
+      innerHTML += `<div><b>Name</b>: ${properties[INDEX_COLUMN]}</div>`;
+
+      if (properties?.year) {
+        innerHTML += `<div><b>Year</b>: ${properties.year}</div>`;
+      }
+
+      // Above/Below Ground Section with Icon
+      const heightAg = properties?.height_ag ?? 0;
+      const heightBg = properties?.height_bg ?? 0;
+      const floorsAg = properties?.floors_ag ?? 0;
+      const floorsBg = properties?.floors_bg ?? 0;
+      const voidDeck = properties?.void_deck ?? 0;
+
+      innerHTML += `
+        <div style="display: flex; align-items: flex-start; gap: 12px; margin-block: 8px;">
+          <div style="flex: 1;">
+            <div style="margin-bottom: 8px;">
+              <div style="font-weight: bold; margin-bottom: 2px;">Above Ground</div>
+              <div>• Height: ${heightAg}m</div>
+              <div>• Floors: ${floorsAg} ${voidDeck > 0 ? `(with ${voidDeck} void decks)` : ''}</div>
+            </div>
+            ${
+              isZone
+                ? `<div>
+              <div style="font-weight: bold; margin-bottom: 2px;">Below Ground</div>
+              <div>• Depth: ${heightBg}m</div>
+              <div>• Floors: ${floorsBg}</div>
+            </div>`
+                : ''
+            }
+          </div>
+        </div>`;
 
       let area = Math.round(turf.area(object) * 1000) / 1000;
-      innerHTML += `<br><div><b>Floor Area</b>: ${area}m<sup>2</sup></div>`;
-      if (layer.id === 'zone') {
-        const floorsAg = Number(properties?.floors_ag ?? 0);
-        const floorsBg = Number(properties?.floors_bg ?? 0);
-        const voidDeck = Number(properties?.void_deck ?? 0);
+      innerHTML += `<div><b>Floor Area</b>: ${area}m<sup>2</sup></div>`;
+      if (isZone) {
         const gfa = Math.max(0, (floorsAg + floorsBg - voidDeck) * area);
 
         innerHTML += `<div><b>GFA</b>: ${Math.round(gfa * 1000) / 1000}m<sup>2</sup></div>`;
@@ -699,7 +724,7 @@ function updateTooltip(feature) {
     tooltip.innerHTML = innerHTML;
 
     // Position tooltip and keep it within screen bounds
-    const offset = 16;
+    const offset = 4;
     const tooltipRect = tooltip.getBoundingClientRect();
     const viewportWidth = window.innerWidth;
     const viewportHeight = window.innerHeight;

--- a/src/features/map/components/Map/Map.jsx
+++ b/src/features/map/components/Map/Map.jsx
@@ -472,13 +472,17 @@ const DeckGLMap = ({ data, colors }) => {
           pickable: false,
           getPosition: (f) => {
             const centroid = turf.centroid(f);
-            return [...centroid.geometry.coordinates, 5];
+            const height = extruded ? (f.properties?.height_ag ?? 0) : 0;
+            return [...centroid.geometry.coordinates, height + 3];
           },
+          sizeUnits: 'meters',
+
           getText: (f) => f.properties[INDEX_COLUMN],
-          getSize: 14,
-          getAngle: 0,
-          getTextAnchor: 'middle',
-          getAlignmentBaseline: 'center',
+          getSize: 6,
+          sizeMinPixels: 3,
+          updateTriggers: {
+            getPosition: [extruded],
+          },
         }),
       );
     }

--- a/src/features/map/components/Map/Map.jsx
+++ b/src/features/map/components/Map/Map.jsx
@@ -648,13 +648,12 @@ function updateTooltip(feature) {
 
     if (layer.id === 'zone' || layer.id === 'surroundings') {
       innerHTML += `<div><b>Name</b>: ${properties[INDEX_COLUMN]}</div><br />`;
-      Object.keys(properties)
-        .sort()
-        .forEach((key) => {
-          if (key === INDEX_COLUMN) return;
-          if (zoneLabels.includes(key))
-            innerHTML += `<div><b>${key}</b>: ${properties[key]}</div>`;
-        });
+      Object.keys(properties).forEach((key) => {
+        if (key === INDEX_COLUMN) return;
+        if (zoneLabels.includes(key))
+          innerHTML += `<div><b>${key}</b>: ${properties[key]}</div>`;
+      });
+
       let area = Math.round(turf.area(object) * 1000) / 1000;
       innerHTML += `<br><div><b>Floor Area</b>: ${area}m<sup>2</sup></div>`;
       if (layer.id === 'zone') {
@@ -664,6 +663,18 @@ function updateTooltip(feature) {
         const gfa = Math.max(0, (floorsAg + floorsBg - voidDeck) * area);
 
         innerHTML += `<div><b>GFA</b>: ${Math.round(gfa * 1000) / 1000}m<sup>2</sup></div>`;
+
+        innerHTML += '<br/><div><b>Use Types</b></div>';
+        for (let i = 1; i < 4; i++) {
+          const usetype = properties?.[`use_type${i}`];
+          const ratio = properties?.[`use_type${i}r`];
+
+          if (usetype && usetype !== 'NONE' && ratio && ratio > 0) {
+            innerHTML += `<div><b>${i}</b>: ${usetype} (${
+              Math.round(ratio * 1000) / 10
+            }%)</div>`;
+          }
+        }
       }
     } else if (
       layer.id === `${THERMAL_NETWORK}-nodes` ||

--- a/src/features/map/components/Map/Map.jsx
+++ b/src/features/map/components/Map/Map.jsx
@@ -479,9 +479,9 @@ const DeckGLMap = ({ data, colors }) => {
           getPosition: (f) => {
             const centroid = turf.centroid(f);
             const height = extruded
-              ? (f.properties?.height_ag ?? 0)
+              ? Number(f.properties?.height_ag ?? 0)
               : // Lift label above void deck if exists when not extruded
-                (f.properties?.void_deck ?? 0) * VOID_DECK_FLOOR_HEIGHT;
+                Number(f.properties?.void_deck ?? 0) * VOID_DECK_FLOOR_HEIGHT;
             return [...centroid.geometry.coordinates, height + 3];
           },
           sizeUnits: 'meters',
@@ -653,7 +653,7 @@ const calcPolygonWithZ = (feature) => {
 
   if (name === null) return coords;
 
-  const voidDeckFloors = feature?.properties?.void_deck ?? 0;
+  const voidDeckFloors = Number(feature?.properties?.void_deck ?? 0);
   return coords.map((coord) =>
     coord.map((c) => [c[0], c[1], voidDeckFloors * VOID_DECK_FLOOR_HEIGHT]),
   );
@@ -661,11 +661,11 @@ const calcPolygonWithZ = (feature) => {
 
 const calcPolygonElevation = (feature) => {
   const name = feature?.properties?.[INDEX_COLUMN];
-  const height_ag = feature?.properties?.height_ag ?? 0;
+  const height_ag = Number(feature?.properties?.height_ag ?? 0);
 
   if (name === null) return height_ag;
 
-  const voidDeckFloors = feature?.properties?.void_deck ?? 0;
+  const voidDeckFloors = Number(feature?.properties?.void_deck ?? 0);
 
   // Prevent negative elevation, which causes buildings to appear higher than height_ag
   return Math.max(height_ag - voidDeckFloors * VOID_DECK_FLOOR_HEIGHT, 0);

--- a/src/features/map/components/Map/Map.jsx
+++ b/src/features/map/components/Map/Map.jsx
@@ -472,7 +472,10 @@ const DeckGLMap = ({ data, colors }) => {
           pickable: false,
           getPosition: (f) => {
             const centroid = turf.centroid(f);
-            const height = extruded ? (f.properties?.height_ag ?? 0) : 0;
+            const height = extruded
+              ? (f.properties?.height_ag ?? 0)
+              : // Lift label above void deck if exists when not extruded
+                (f.properties?.void_deck ?? 0) * VOID_DECK_FLOOR_HEIGHT;
             return [...centroid.geometry.coordinates, height + 3];
           },
           sizeUnits: 'meters',

--- a/src/features/map/components/Map/Map.jsx
+++ b/src/features/map/components/Map/Map.jsx
@@ -629,6 +629,14 @@ const DeckGLMap = ({ data, colors }) => {
   );
 };
 
+const zoneLabels = [
+  'height_ag',
+  'height_bg',
+  'floors_ag',
+  'floors_bg',
+  'void_deck',
+  'year',
+];
 function updateTooltip(feature) {
   const { x, y, object, layer } = feature;
   const tooltip = document.getElementById('map-tooltip');
@@ -643,7 +651,8 @@ function updateTooltip(feature) {
       Object.keys(properties)
         .sort()
         .forEach((key) => {
-          if (key != INDEX_COLUMN)
+          if (key === INDEX_COLUMN) return;
+          if (zoneLabels.includes(key))
             innerHTML += `<div><b>${key}</b>: ${properties[key]}</div>`;
         });
       let area = Math.round(turf.area(object) * 1000) / 1000;

--- a/src/features/map/components/Map/Map.jsx
+++ b/src/features/map/components/Map/Map.jsx
@@ -688,11 +688,11 @@ function updateTooltip(feature) {
       innerHTML += `
         <div class="tooltip-section-title">Floor Area</div>
         <div class="tooltip-grid">
-          <div>Footprint</div><b>${area} m<sup>2</sup></b>
+          <div>Footprint</div><b style="margin-left: auto;">${area.toLocaleString()} m<sup>2</sup></b>
           ${
             isZone
               ? `
-          <div>GFA</div><b>${Math.round(Math.max(0, (floorsAg + floorsBg - voidDeck) * area) * 1000) / 1000} m<sup>2</sup></b>`
+          <div>GFA</div><b style="margin-left: auto;">${(Math.round(Math.max(0, (floorsAg + floorsBg - voidDeck) * area) * 1000) / 1000).toLocaleString()} m<sup>2</sup></b>`
               : ''
           }
         </div>`;

--- a/src/features/map/components/Map/Map.jsx
+++ b/src/features/map/components/Map/Map.jsx
@@ -665,32 +665,40 @@ function updateTooltip(feature) {
           <div class="tooltip-section">
             <div class="tooltip-section-title">Above Ground</div>
             <div class="tooltip-grid">
-              <div>Height</div><div><span class="tooltip-value-above-ground">${heightAg} m</span></div>
-              <div>Floors</div><div><span class="tooltip-value-above-ground">${floorsAg}</span></div>
-              ${isZone ? `<div>Void deck</div><div><span class="tooltip-value-above-ground">${voidDeck}</span></div>` : ''}
+              <div>Height</div><b>${heightAg} m</b>
+              <div>Floors</div><b>${floorsAg}</b>
+              ${isZone ? `<div>Void deck</div><b>${voidDeck}</b>` : ''}
             </div>
           </div>
           ${
             isZone
-              ? `<div class="tooltip-section">
-            <div class="tooltip-section-title">Below Ground</div>
-            <div class="tooltip-grid">
-              <div>Depth</div><div><span class="tooltip-value-below-ground">${heightBg} m</span></div>
-              <div>Floors</div><div><span class="tooltip-value-below-ground">${floorsBg}</span></div>
-            </div>
-          </div>`
+              ? `
+            <div class="tooltip-section">
+              <div class="tooltip-section-title">Below Ground</div>
+              <div class="tooltip-grid">
+                <div>Depth</div><b>${heightBg} m</b>
+                <div>Floors</div><b>${floorsBg}</b>
+              </div>
+            </div>`
               : ''
           }
         </div>`;
 
       let area = Math.round(turf.area(object) * 1000) / 1000;
-      innerHTML += `<div><b>Floor Area</b>: ${area} m<sup>2</sup></div>`;
+      innerHTML += `
+        <div class="tooltip-section-title">Floor Area</div>
+        <div class="tooltip-grid">
+          <div>Footprint</div><b>${area} m<sup>2</sup></b>
+          ${
+            isZone
+              ? `
+          <div>GFA</div><b>${Math.round(Math.max(0, (floorsAg + floorsBg - voidDeck) * area) * 1000) / 1000} m<sup>2</sup></b>`
+              : ''
+          }
+        </div>`;
+
       if (isZone) {
-        const gfa = Math.max(0, (floorsAg + floorsBg - voidDeck) * area);
-
-        innerHTML += `<div><b>GFA</b>: ${Math.round(gfa * 1000) / 1000} m<sup>2</sup></div>`;
-
-        innerHTML += '<br/><div><b>Use Types</b></div>';
+        innerHTML += '<br/><div class="tooltip-section-title">Use Types</div>';
         for (let i = 1; i < 4; i++) {
           const usetype = properties?.[`use_type${i}`];
           const ratio = properties?.[`use_type${i}r`];

--- a/src/features/map/components/Map/Map.jsx
+++ b/src/features/map/components/Map/Map.jsx
@@ -642,8 +642,6 @@ function updateTooltip(feature) {
   const tooltip = document.getElementById('map-tooltip');
   if (object) {
     const { properties } = object;
-    tooltip.style.top = `${y}px`;
-    tooltip.style.left = `${x}px`;
     let innerHTML = '';
 
     if (layer.id === 'zone' || layer.id === 'surroundings') {
@@ -699,6 +697,38 @@ function updateTooltip(feature) {
     }
 
     tooltip.innerHTML = innerHTML;
+
+    // Position tooltip and keep it within screen bounds
+    const offset = 16;
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    let left = x + offset;
+    let top = y + offset;
+
+    // Adjust horizontal position if tooltip goes off right edge
+    if (left + tooltipRect.width > viewportWidth) {
+      left = x - tooltipRect.width - offset;
+    }
+
+    // Adjust vertical position if tooltip goes off bottom edge
+    if (top + tooltipRect.height > viewportHeight) {
+      top = y - tooltipRect.height - offset;
+    }
+
+    // Ensure tooltip doesn't go off left edge
+    if (left < 0) {
+      left = offset;
+    }
+
+    // Ensure tooltip doesn't go off top edge
+    if (top < 0) {
+      top = offset;
+    }
+
+    tooltip.style.left = `${left}px`;
+    tooltip.style.top = `${top}px`;
   } else {
     tooltip.innerHTML = '';
   }

--- a/src/features/map/components/Map/Map.jsx
+++ b/src/features/map/components/Map/Map.jsx
@@ -435,7 +435,7 @@ const DeckGLMap = ({ data, colors }) => {
     if (data?.zone) {
       _layers.push(
         new PolygonLayer({
-          id: 'zone-polygon',
+          id: 'zone',
           data: data.zone?.features,
           opacity: 0.5,
           wireframe: true,

--- a/src/features/map/components/Map/Map.jsx
+++ b/src/features/map/components/Map/Map.jsx
@@ -629,14 +629,6 @@ const DeckGLMap = ({ data, colors }) => {
   );
 };
 
-const zoneLabels = [
-  'height_ag',
-  'height_bg',
-  'floors_ag',
-  'floors_bg',
-  'void_deck',
-  'year',
-];
 function updateTooltip(feature) {
   const { x, y, object, layer } = feature;
   const tooltip = document.getElementById('map-tooltip');

--- a/src/features/map/components/Map/Map.jsx
+++ b/src/features/map/components/Map/Map.jsx
@@ -468,7 +468,7 @@ const DeckGLMap = ({ data, colors }) => {
         new TextLayer({
           id: 'zone-labels',
           data: data.zone?.features,
-          visible: visibility.zone,
+          visible: visibility.zone_labels ?? true,
           pickable: false,
           getPosition: (f) => {
             const centroid = turf.centroid(f);

--- a/src/features/map/components/Map/MapTooltip.css
+++ b/src/features/map/components/Map/MapTooltip.css
@@ -37,7 +37,12 @@
   gap: 2px 12px;
 }
 
-#map-tooltip th + th,
-#map-tooltip td + td {
+.tooltip-table th + th,
+.tooltip-table td + td {
   padding-inline-start: 1.6em;
+}
+
+.tooltip-table th {
+  text-align: left;
+  font-weight: normal;
 }

--- a/src/features/map/components/Map/MapTooltip.css
+++ b/src/features/map/components/Map/MapTooltip.css
@@ -36,3 +36,8 @@
   grid-template-columns: auto 1fr;
   gap: 2px 12px;
 }
+
+#map-tooltip th + th,
+#map-tooltip td + td {
+  padding-inline-start: 1.6em;
+}

--- a/src/features/map/components/Map/MapTooltip.css
+++ b/src/features/map/components/Map/MapTooltip.css
@@ -1,0 +1,38 @@
+#map-tooltip {
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue',
+    Arial, sans-serif;
+  font-size: 12px;
+  position: absolute;
+  padding: 8px 12px;
+  margin: 8px;
+  background: rgba(20, 20, 30, 0.8);
+  backdrop-filter: blur(2px);
+  color: #fff;
+  max-width: 320px;
+  z-index: 9;
+  pointer-events: none;
+  user-select: none;
+  border-radius: 8px;
+  box-shadow:
+    0 4px 12px rgba(0, 0, 0, 0.4),
+    0 0 0 1px rgba(255, 255, 255, 0.1);
+  line-height: 1.5;
+}
+
+.tooltip-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.tooltip-section-title {
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+
+.tooltip-grid {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 12px;
+}

--- a/src/features/map/components/Map/MapTooltip.jsx
+++ b/src/features/map/components/Map/MapTooltip.jsx
@@ -40,7 +40,7 @@ const MapTooltip = ({ info }) => {
   const { x, y, object, layer } = info || {};
 
   useEffect(() => {
-    if (!x || !y || !tooltipRef.current) return;
+    if (x == null || y == null || !tooltipRef.current) return;
 
     const tooltipRect = tooltipRef.current.getBoundingClientRect();
     setPosition(calculatePosition(x, y, tooltipRect));

--- a/src/features/map/components/Map/MapTooltip.jsx
+++ b/src/features/map/components/Map/MapTooltip.jsx
@@ -3,6 +3,8 @@ import * as turf from '@turf/turf';
 import { INDEX_COLUMN } from 'features/input-editor/constants';
 import { THERMAL_NETWORK } from 'features/map/constants';
 
+import './MapTooltip.css';
+
 const calculatePosition = (x, y, tooltipRect) => {
   const offset = 4;
   let left = x + offset;

--- a/src/features/map/components/Map/MapTooltip.jsx
+++ b/src/features/map/components/Map/MapTooltip.jsx
@@ -56,9 +56,11 @@ const MapTooltip = ({ info }) => {
     const footprintArea = Math.round(area * 1000) / 1000;
 
     if (isZone || layer.id === 'surroundings') {
-      const floorsAg = properties?.floors_ag ?? 0;
-      const floorsBg = properties?.floors_bg ?? 0;
-      const voidDeck = properties?.void_deck ?? 0;
+      const heightAg = Number(properties?.height_ag ?? 0);
+      const heightBg = Number(properties?.height_bg ?? 0);
+      const floorsAg = Number(properties?.floors_ag ?? 0);
+      const floorsBg = Number(properties?.floors_bg ?? 0);
+      const voidDeck = Number(properties?.void_deck ?? 0);
       const gfaArea =
         Math.round(
           Math.max(0, (floorsAg + floorsBg - voidDeck) * area) * 1000,
@@ -90,11 +92,11 @@ const MapTooltip = ({ info }) => {
                 <tr>
                   <td>Height</td>
                   <td>
-                    <b>{properties?.height_ag ?? 0} m</b>
+                    <b>{heightAg} m</b>
                   </td>
                   {isZone && (
                     <td>
-                      <b>{properties?.height_bg ?? 0} m</b>
+                      <b>{heightBg} m</b>
                     </td>
                   )}
                 </tr>

--- a/src/features/map/components/Map/MapTooltip.jsx
+++ b/src/features/map/components/Map/MapTooltip.jsx
@@ -65,66 +65,74 @@ const MapTooltip = ({ info }) => {
         ) / 1000;
 
       return (
-        <>
+        <div className="tooltip-content">
           <div style={{ fontWeight: 'bold', marginBottom: '4px' }}>
             {properties[INDEX_COLUMN]}
           </div>
 
           {properties?.year && (
-            <div>
-              <b>Year</b>: {properties.year}
+            <div className="tooltip-grid">
+              <div>Year</div>
+              <b style={{ marginLeft: 'auto' }}>{properties.year}</b>
             </div>
           )}
 
-          <div className="tooltip-building-details">
-            <div className="tooltip-section">
-              <div className="tooltip-section-title">Above Ground</div>
-              <div className="tooltip-grid">
-                <div>Height</div>
-                <b>{properties?.height_ag ?? 0} m</b>
-                <div>Floors</div>
-                <b>{floorsAg}</b>
+          <div>
+            <table>
+              <thead>
+                <tr>
+                  <th></th>
+                  <th>Above</th>
+                  {isZone && <th>Below</th>}
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Height</td>
+                  <td>
+                    <b>{properties?.height_ag ?? 0} m</b>
+                  </td>
+                  {isZone && (
+                    <td>
+                      <b>{properties?.height_bg ?? 0} m</b>
+                    </td>
+                  )}
+                </tr>
+                <tr>
+                  <td>Floors</td>
+                  <td>{<b>{floorsAg}</b>}</td>
+                  {isZone && <td>{<b>{floorsBg}</b>}</td>}
+                </tr>
                 {isZone && (
-                  <>
-                    <div>Void deck</div>
-                    <b>{voidDeck}</b>
-                  </>
+                  <tr>
+                    <td>Void deck</td>
+                    <td colSpan={2}>{<b>{voidDeck}</b>}</td>
+                  </tr>
                 )}
-              </div>
-            </div>
-
-            {isZone && (
-              <div className="tooltip-section">
-                <div className="tooltip-section-title">Below Ground</div>
-                <div className="tooltip-grid">
-                  <div>Depth</div>
-                  <b>{properties?.height_bg ?? 0} m</b>
-                  <div>Floors</div>
-                  <b>{floorsBg}</b>
-                </div>
-              </div>
-            )}
+              </tbody>
+            </table>
           </div>
 
-          <div className="tooltip-section-title">Floor Area</div>
-          <div className="tooltip-grid">
-            <div>Footprint</div>
-            <b style={{ marginLeft: 'auto' }}>
-              {footprintArea.toLocaleString()} m<sup>2</sup>
-            </b>
-            {isZone && (
-              <>
-                <div>GFA</div>
-                <b style={{ marginLeft: 'auto' }}>
-                  {gfaArea.toLocaleString()} m<sup>2</sup>
-                </b>
-              </>
-            )}
+          <div>
+            <div className="tooltip-section-title">Floor Area</div>
+            <div className="tooltip-grid">
+              <div>Footprint</div>
+              <b style={{ marginLeft: 'auto' }}>
+                {footprintArea.toLocaleString()} m<sup>2</sup>
+              </b>
+              {isZone && (
+                <>
+                  <div>GFA</div>
+                  <b style={{ marginLeft: 'auto' }}>
+                    {gfaArea.toLocaleString()} m<sup>2</sup>
+                  </b>
+                </>
+              )}
+            </div>
           </div>
 
           {isZone && (
-            <>
-              <br />
+            <div>
               <div className="tooltip-section-title">Use Types</div>
               {[1, 2, 3].map((i) => {
                 const usetype = properties?.[`use_type${i}`];
@@ -150,9 +158,9 @@ const MapTooltip = ({ info }) => {
                   </div>
                 );
               })}
-            </>
+            </div>
           )}
-        </>
+        </div>
       );
     }
 

--- a/src/features/map/components/Map/MapTooltip.jsx
+++ b/src/features/map/components/Map/MapTooltip.jsx
@@ -1,0 +1,212 @@
+import { useRef, useEffect, useState, useMemo } from 'react';
+import * as turf from '@turf/turf';
+import { INDEX_COLUMN } from 'features/input-editor/constants';
+import { THERMAL_NETWORK } from 'features/map/constants';
+
+const calculatePosition = (x, y, tooltipRect) => {
+  const offset = 4;
+  let left = x + offset;
+  let top = y + offset;
+
+  // Adjust horizontal position if tooltip goes off right edge
+  if (left + tooltipRect.width > window.innerWidth) {
+    left = x - tooltipRect.width - offset;
+  }
+
+  // Adjust vertical position if tooltip goes off bottom edge
+  if (top + tooltipRect.height > window.innerHeight) {
+    top = y - tooltipRect.height - offset;
+  }
+
+  // Ensure tooltip doesn't go off left edge
+  if (left < 0) {
+    left = offset;
+  }
+
+  // Ensure tooltip doesn't go off top edge
+  if (top < 0) {
+    top = offset;
+  }
+
+  return { x: left, y: top };
+};
+
+const MapTooltip = ({ info }) => {
+  const tooltipRef = useRef(null);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+
+  const { x, y, object, layer } = info || {};
+
+  useEffect(() => {
+    if (!x || !y || !tooltipRef.current) return;
+
+    const tooltipRect = tooltipRef.current.getBoundingClientRect();
+    setPosition(calculatePosition(x, y, tooltipRect));
+  }, [x, y]);
+
+  // Memoize expensive calculations
+  const tooltipContent = useMemo(() => {
+    if (!object) return null;
+
+    const { properties } = object;
+    const isZone = layer.id === 'zone';
+
+    // Cache area calculation
+    const area = turf.area(object);
+    const footprintArea = Math.round(area * 1000) / 1000;
+
+    if (isZone || layer.id === 'surroundings') {
+      const floorsAg = properties?.floors_ag ?? 0;
+      const floorsBg = properties?.floors_bg ?? 0;
+      const voidDeck = properties?.void_deck ?? 0;
+      const gfaArea =
+        Math.round(
+          Math.max(0, (floorsAg + floorsBg - voidDeck) * area) * 1000,
+        ) / 1000;
+
+      return (
+        <>
+          <div style={{ fontWeight: 'bold', marginBottom: '4px' }}>
+            {properties[INDEX_COLUMN]}
+          </div>
+
+          {properties?.year && (
+            <div>
+              <b>Year</b>: {properties.year}
+            </div>
+          )}
+
+          <div className="tooltip-building-details">
+            <div className="tooltip-section">
+              <div className="tooltip-section-title">Above Ground</div>
+              <div className="tooltip-grid">
+                <div>Height</div>
+                <b>{properties?.height_ag ?? 0} m</b>
+                <div>Floors</div>
+                <b>{floorsAg}</b>
+                {isZone && (
+                  <>
+                    <div>Void deck</div>
+                    <b>{voidDeck}</b>
+                  </>
+                )}
+              </div>
+            </div>
+
+            {isZone && (
+              <div className="tooltip-section">
+                <div className="tooltip-section-title">Below Ground</div>
+                <div className="tooltip-grid">
+                  <div>Depth</div>
+                  <b>{properties?.height_bg ?? 0} m</b>
+                  <div>Floors</div>
+                  <b>{floorsBg}</b>
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="tooltip-section-title">Floor Area</div>
+          <div className="tooltip-grid">
+            <div>Footprint</div>
+            <b style={{ marginLeft: 'auto' }}>
+              {footprintArea.toLocaleString()} m<sup>2</sup>
+            </b>
+            {isZone && (
+              <>
+                <div>GFA</div>
+                <b style={{ marginLeft: 'auto' }}>
+                  {gfaArea.toLocaleString()} m<sup>2</sup>
+                </b>
+              </>
+            )}
+          </div>
+
+          {isZone && (
+            <>
+              <br />
+              <div className="tooltip-section-title">Use Types</div>
+              {[1, 2, 3].map((i) => {
+                const usetype = properties?.[`use_type${i}`];
+                const ratio = properties?.[`use_type${i}r`];
+
+                if (!usetype || usetype === 'NONE' || !ratio || ratio <= 0) {
+                  return null;
+                }
+
+                return (
+                  <div key={i} className="tooltip-grid">
+                    <div>
+                      {i}:{' '}
+                      <span
+                        style={{ fontFamily: "'Space Grotesk', sans-serif" }}
+                      >
+                        {usetype}
+                      </span>
+                    </div>
+                    <b style={{ marginLeft: 'auto' }}>
+                      ({Math.round(ratio * 1000) / 10}%)
+                    </b>
+                  </div>
+                );
+              })}
+            </>
+          )}
+        </>
+      );
+    }
+
+    if (
+      layer.id === `${THERMAL_NETWORK}-nodes` ||
+      layer.id === `${THERMAL_NETWORK}-edges`
+    ) {
+      const length = properties['Buildings']
+        ? Math.round(turf.length(object) * 1000 * 1000) / 1000
+        : null;
+
+      return (
+        <>
+          {Object.keys(properties).map((key) => {
+            if (key !== 'Building' && properties[key] === 'NONE') return null;
+            if (key === 'type_mat') return null;
+
+            return (
+              <div key={key}>
+                <b>{key}</b>: {properties[key]}
+              </div>
+            );
+          })}
+          {length !== null && (
+            <>
+              <br />
+              <div>
+                <b>length</b>: {length}m
+              </div>
+            </>
+          )}
+        </>
+      );
+    }
+
+    // Default fallback for other layer types
+    return Object.keys(properties).map((key) => (
+      <div key={key}>
+        <b>{key}</b>: {properties[key]}
+      </div>
+    ));
+  }, [object, layer]);
+
+  if (!tooltipContent) return null;
+
+  return (
+    <div
+      ref={tooltipRef}
+      id="map-tooltip"
+      style={{ left: `${position.x}px`, top: `${position.y}px` }}
+    >
+      {tooltipContent}
+    </div>
+  );
+};
+
+export default MapTooltip;

--- a/src/features/map/components/Map/MapTooltip.jsx
+++ b/src/features/map/components/Map/MapTooltip.jsx
@@ -70,9 +70,9 @@ const MapTooltip = ({ info }) => {
 
       return (
         <div className="tooltip-content">
-          <div style={{ fontWeight: 'bold', marginBottom: '4px' }}>
+          <b style={{ fontSize: '1.2em', marginBottom: '4px' }}>
             {properties[INDEX_COLUMN]}
-          </div>
+          </b>
 
           {properties?.year && (
             <div className="tooltip-grid">
@@ -81,7 +81,7 @@ const MapTooltip = ({ info }) => {
             </div>
           )}
 
-          <table>
+          <table className="tooltip-table">
             <thead>
               <tr>
                 <th></th>

--- a/src/features/map/components/Map/MapTooltip.jsx
+++ b/src/features/map/components/Map/MapTooltip.jsx
@@ -81,41 +81,39 @@ const MapTooltip = ({ info }) => {
             </div>
           )}
 
-          <div>
-            <table>
-              <thead>
-                <tr>
-                  <th></th>
-                  <th>Above</th>
-                  {isZone && <th>Below</th>}
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>Height</td>
-                  <td>
-                    <b>{heightAg} m</b>
-                  </td>
-                  {isZone && (
-                    <td>
-                      <b>{heightBg} m</b>
-                    </td>
-                  )}
-                </tr>
-                <tr>
-                  <td>Floors</td>
-                  <td>{<b>{floorsAg}</b>}</td>
-                  {isZone && <td>{<b>{floorsBg}</b>}</td>}
-                </tr>
+          <table>
+            <thead>
+              <tr>
+                <th></th>
+                <th>Above</th>
+                {isZone && <th>Below</th>}
+              </tr>
+            </thead>
+            <tbody>
+              <tr>
+                <td>Height</td>
+                <td>
+                  <b>{heightAg} m</b>
+                </td>
                 {isZone && (
-                  <tr>
-                    <td>Void deck</td>
-                    <td colSpan={2}>{<b>{voidDeck}</b>}</td>
-                  </tr>
+                  <td>
+                    <b>{heightBg} m</b>
+                  </td>
                 )}
-              </tbody>
-            </table>
-          </div>
+              </tr>
+              <tr>
+                <td>Floors</td>
+                <td>{<b>{floorsAg}</b>}</td>
+                {isZone && <td>{<b>{floorsBg}</b>}</td>}
+              </tr>
+              {isZone && (
+                <tr>
+                  <td>Void deck</td>
+                  <td colSpan={2}>{<b>{voidDeck}</b>}</td>
+                </tr>
+              )}
+            </tbody>
+          </table>
 
           <div>
             <div className="tooltip-section-title">Floor Area</div>

--- a/src/features/map/components/Map/MapTooltip.jsx
+++ b/src/features/map/components/Map/MapTooltip.jsx
@@ -166,35 +166,69 @@ const MapTooltip = ({ info }) => {
       );
     }
 
-    if (
-      layer.id === `${THERMAL_NETWORK}-nodes` ||
-      layer.id === `${THERMAL_NETWORK}-edges`
-    ) {
-      const length = properties['Buildings']
-        ? Math.round(turf.length(object) * 1000 * 1000) / 1000
+    if (layer.id === `${THERMAL_NETWORK}-edges`) {
+      const length = properties?.length_m
+        ? Math.round(properties?.length_m * 1000) / 1000
+        : null;
+
+      const pipeDiameter = properties?.pipe_DN
+        ? Math.round(Number(properties.pipe_DN) * 100) / 100
+        : null;
+
+      const peakMassFlow = properties?.peak_mass_flow
+        ? Math.round(Number(properties.peak_mass_flow) * 1000) / 1000
         : null;
 
       return (
-        <>
-          {Object.keys(properties).map((key) => {
-            if (key !== 'Building' && properties[key] === 'NONE') return null;
-            if (key === 'type_mat') return null;
+        <div className="tooltip-content">
+          <b style={{ fontSize: '1.2em', marginBottom: '4px' }}>Network Pipe</b>
 
-            return (
-              <div key={key}>
-                <b>{key}</b>: {properties[key]}
-              </div>
-            );
-          })}
-          {length !== null && (
-            <>
-              <br />
-              <div>
-                <b>length</b>: {length}m
-              </div>
-            </>
-          )}
-        </>
+          <div className="tooltip-grid">
+            <div>ID</div>
+            <b style={{ marginLeft: 'auto' }}>{object?.id}</b>
+          </div>
+
+          <div className="tooltip-grid">
+            {length !== null && (
+              <>
+                <div>Length</div>
+                <b style={{ marginLeft: 'auto' }}>{length} m</b>
+              </>
+            )}
+            {pipeDiameter !== null && (
+              <>
+                <div>Nominal pipe diameter (DN)</div>
+                <b style={{ marginLeft: 'auto' }}>{pipeDiameter}</b>
+              </>
+            )}
+          </div>
+
+          <div className="tooltip-grid">
+            <div>Peak Mass Flow</div>
+            <b style={{ marginLeft: 'auto' }}>
+              {peakMassFlow !== null ? `${peakMassFlow} kg/s` : 'N/A'}
+            </b>
+          </div>
+        </div>
+      );
+    } else if (layer.id === `${THERMAL_NETWORK}-nodes`) {
+      if (properties?.type === 'NONE') return null;
+
+      return (
+        <div className="tooltip-content">
+          <b style={{ fontSize: '1.2em', marginBottom: '4px' }}>Network Node</b>
+          <div className="tooltip-grid">
+            <div>ID</div>
+            <b style={{ marginLeft: 'auto' }}>{object?.id}</b>
+          </div>
+
+          <div className="tooltip-grid">
+            <div>Building</div>
+            <b style={{ marginLeft: 'auto' }}>{properties?.building}</b>
+            <div>Type</div>
+            <b style={{ marginLeft: 'auto' }}>{properties?.type}</b>
+          </div>
+        </div>
       );
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Zone names render as dedicated map labels positioned at centroids with extrusion-aware offsets.
  - Map layers now include separate text layers so labels and geometry render in proper order.
  - New contextual map tooltip displays structured, viewport-aware popups with area/length and layer-specific details.

- **UI Improvements**
  - Layer controls reorganized into Geometry, Labels (Building Names enabled by default when zones exist), and Map Style groups.
  - Tooltips present curated zone properties, Use Types breakdown, footprint/GFA, and clearer Above/Below Ground sections with improved styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->