### PR TITLE
Add weather morph as an option for weather parameter

### DIFF
--- a/src/components/Parameter.jsx
+++ b/src/components/Parameter.jsx
@@ -260,7 +260,6 @@ const Parameter = ({ parameter, form }) => {
     }
 
     case 'WeatherPathParameter': {
-      const { choices } = parameter;
       return (
         <FormItemWrapper
           form={form}
@@ -275,22 +274,12 @@ const Parameter = ({ parameter, form }) => {
               filters={[{ name: 'Weather files', extensions: ['epw'] }]}
               options={[
                 {
-                  label: 'Third-party sources',
-                  options: [
-                    {
-                      label: 'Fetch from climate.onebuilding.org',
-                      value: 'climate.onebuilding.org',
-                    },
-                  ],
+                  label: 'Fetch from climate.onebuilding.org',
+                  value: 'climate.onebuilding.org',
                 },
                 {
-                  label: 'CEA Built-in',
-                  options: Object.keys(choices).map((choice) => {
-                    return {
-                      label: choice,
-                      value: choices[choice],
-                    };
-                  }),
+                  label: 'Generate a future weather file using pyepwmorph',
+                  value: 'pyepwmorph',
                 },
               ]}
             >


### PR DESCRIPTION
Replaces nested option groups for weather file sources with direct options for 'climate.onebuilding.org' and 'pyepwmorph', removing dynamic choices and streamlining the selection UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified weather source selection: replaced nested option groups with a flat list of two options—“Fetch from climate.onebuilding.org” and “Generate a future weather file using pyepwmorph”—for a clearer, faster choice.
  * Updated selection values to match the new options.

* **Refactor**
  * Removed grouped options to streamline the selection experience and reduce complexity in the weather file input control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->