### PR TITLE
Remove /api prefix from all API endpoint paths

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,16 +12,19 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      # Must run before setup-node: with `cache: yarn` below, setup-node
+      # itself shells out to `yarn` to resolve the cache directory. Until
+      # Corepack is enabled, the runner's global Yarn is classic 1.22, which
+      # refuses to run at all against a package.json pinning
+      # packageManager: yarn@4.12.0 - so this has to come first, not after.
+      - name: Enable Corepack
+        run: corepack enable
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: yarn
-
-      # package.json pins packageManager: yarn@4.12.0 - without this,
-      # setup-node's bundled classic Yarn would run instead.
-      - name: Enable Corepack
-        run: corepack enable
 
       - name: Install dependencies
         run: yarn install --immutable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      # package.json pins packageManager: yarn@4.12.0 - without this,
+      # setup-node's bundled classic Yarn would run instead.
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run tests
+        run: yarn test

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -104,4 +104,23 @@ module.exports = [
       'sonarjs/no-unused-vars': 'off',
     },
   },
+  {
+    // Vitest's `globals: true` config injects describe/it/expect/vi/etc as
+    // real globals at runtime - declare them here too so lint doesn't flag
+    // every test file for using them.
+    files: ['**/*.test.{js,jsx}', 'src/test/**/*.{js,jsx}'],
+    languageOptions: {
+      globals: {
+        describe: 'readonly',
+        it: 'readonly',
+        test: 'readonly',
+        expect: 'readonly',
+        vi: 'readonly',
+        beforeEach: 'readonly',
+        afterEach: 'readonly',
+        beforeAll: 'readonly',
+        afterAll: 'readonly',
+      },
+    },
+  },
 ];

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "dev-electron": "vite --mode electron",
     "build-electron": "vite build --config vite.electron.config.js && vite build --mode electron",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint:fix": "eslint ./src --quiet --fix",
     "lint:format": "prettier --log-level warn --write \"./**/*.{js,jsx,ts,tsx,css,md,json}\" ",
     "electron:dev": "concurrently \"yarn dev-electron\" \"wait-on http://localhost:5173 && electron .\"",
@@ -32,6 +34,10 @@
   "devDependencies": {
     "@eslint/js": "^9.39.5",
     "@tanstack/eslint-plugin-query": "^5.101.2",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^7.0.0",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
@@ -52,10 +58,12 @@
     "eslint-plugin-sonarjs": "^4.2.0",
     "eslint-plugin-unused-imports": "^4.4.1",
     "globals": "^17.7.0",
+    "jsdom": "^30.0.1",
     "prettier": "^3.7.4",
     "vite": "^8.1.5",
     "vite-plugin-svgr": "^5.2.0",
     "vite-tsconfig-paths": "^6.1.1",
+    "vitest": "^4.1.10",
     "wait-on": "^9.0.3"
   },
   "dependencies": {

--- a/src/app/UserCheckGate.jsx
+++ b/src/app/UserCheckGate.jsx
@@ -14,7 +14,7 @@ import { useProjectStore } from 'features/project/stores/projectStore';
 // and the project store, so anonymous visitors (no valid session) see the
 // project page rendered against a read-only demo scenario instead of an
 // empty state. See stores/demoStore.js and lib/api/axios.js's demoClient
-// for how requests get transparently routed to `/api/demo/...` from there.
+// for how requests get transparently routed to `/demo/...` from there.
 //
 // `userInfo` drives the transition both ways: `null` means "confirmed no
 // session" (enter demo mode); a real user object means a session appeared
@@ -44,11 +44,11 @@ const useInitDemoStore = (userInfo) => {
     let cancelled = false;
     (async () => {
       try {
-        const { data } = await publicClient.get('/api/demo/scenarios');
+        const { data } = await publicClient.get('/demo/scenarios');
         const scenarios = data?.scenarios ?? [];
         if (cancelled) return;
 
-        enterDemo(scenarios);
+        enterDemo(scenarios, data?.route_prefixes ?? []);
         if (scenarios.length) {
           seedDemoProject({
             scenario: scenarios[0].id,

--- a/src/app/UserCheckGate.test.jsx
+++ b/src/app/UserCheckGate.test.jsx
@@ -1,0 +1,129 @@
+import { render, waitFor } from '@testing-library/react';
+
+import useDemoStore from 'stores/demoStore';
+import { useProjectStore } from 'features/project/stores/projectStore';
+import { useUserQuery } from 'stores/useUserQuery';
+import { isElectron } from 'utils/electron';
+import { publicClient } from 'lib/api/axios';
+
+import UserCheckGate from './UserCheckGate';
+
+// vi.mock calls are hoisted above these imports by Vitest, so the bindings
+// above already resolve to the mocked implementations.
+vi.mock('stores/useUserQuery', () => ({
+  useUserQuery: vi.fn(),
+  useIsValidUser: vi.fn(() => true),
+}));
+
+vi.mock('stores/serverStore', () => ({
+  useFetchServerLimits: vi.fn(() => vi.fn()),
+}));
+
+vi.mock('utils/electron', () => ({
+  isElectron: vi.fn(() => false),
+}));
+
+vi.mock('lib/api/axios', async () => {
+  const actual = await vi.importActual('lib/api/axios');
+  return {
+    ...actual,
+    publicClient: { get: vi.fn() },
+  };
+});
+
+const mockUserQuery = (userInfo, extra = {}) => {
+  useUserQuery.mockReturnValue({
+    data: userInfo,
+    isLoading: false,
+    isError: false,
+    ...extra,
+  });
+};
+
+const initialDemoState = useDemoStore.getInitialState();
+const initialProjectState = useProjectStore.getInitialState();
+
+beforeEach(() => {
+  useDemoStore.setState(initialDemoState, true);
+  useProjectStore.setState(initialProjectState, true);
+  isElectron.mockReturnValue(false);
+  publicClient.get.mockReset();
+});
+
+describe('anonymous visitor (userInfo === null)', () => {
+  it('fetches /demo/scenarios and enters demo mode with both the scenario list and route_prefixes', async () => {
+    const scenarios = [{ id: 'baseline', name: 'baseline' }];
+    const routePrefixes = ['/inputs/', '/canvas/'];
+    publicClient.get.mockResolvedValue({
+      data: { scenarios, route_prefixes: routePrefixes },
+    });
+    mockUserQuery(null);
+
+    render(<UserCheckGate>content</UserCheckGate>);
+
+    await waitFor(() => {
+      expect(publicClient.get).toHaveBeenCalledWith('/demo/scenarios');
+    });
+    await waitFor(() => {
+      expect(useDemoStore.getState().demoMode).toBe(true);
+    });
+    expect(useDemoStore.getState().demoId).toBe('baseline');
+    expect(useDemoStore.getState().routePrefixes).toEqual(routePrefixes);
+    expect(useProjectStore.getState().scenario).toBe('baseline');
+  });
+
+  it('falls back to an empty demo scenario list on a failed fetch, instead of a stuck or thrown state', async () => {
+    publicClient.get.mockRejectedValue(new Error('network error'));
+    mockUserQuery(null);
+
+    render(<UserCheckGate>content</UserCheckGate>);
+
+    await waitFor(() => {
+      expect(useDemoStore.getState().demoMode).toBe(true);
+    });
+    expect(useDemoStore.getState().demoId).toBeNull();
+    expect(useDemoStore.getState().demoScenarios).toEqual([]);
+  });
+});
+
+describe('Electron', () => {
+  it('never fetches the demo scenario list', async () => {
+    isElectron.mockReturnValue(true);
+    mockUserQuery(null);
+
+    render(<UserCheckGate>content</UserCheckGate>);
+
+    // Nothing to await on directly - give any stray effect a tick, then
+    // assert the fetch never happened.
+    await Promise.resolve();
+    expect(publicClient.get).not.toHaveBeenCalled();
+    expect(useDemoStore.getState().demoMode).toBe(false);
+  });
+});
+
+describe('a session appears while in demo mode', () => {
+  it('exits demo mode and clears the seeded demo project', async () => {
+    useDemoStore.setState({
+      demoMode: true,
+      demoId: 'baseline',
+      demoScenarios: [{ id: 'baseline' }],
+      routePrefixes: ['/inputs/'],
+    });
+    useProjectStore.setState({
+      name: 'Demo',
+      project: '__demo__',
+      scenario: 'baseline',
+      scenariosList: ['baseline'],
+    });
+    mockUserQuery({ id: 'user-1', onboarded: true });
+
+    render(<UserCheckGate>content</UserCheckGate>);
+
+    await waitFor(() => {
+      expect(useDemoStore.getState().demoMode).toBe(false);
+    });
+    expect(useDemoStore.getState().routePrefixes).toEqual([]);
+    expect(useProjectStore.getState().project).toBeNull();
+    expect(publicClient.get).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/OnboardingPage.jsx
+++ b/src/components/OnboardingPage.jsx
@@ -92,7 +92,7 @@ const OnboardingPage = ({ onComplete }) => {
     });
 
     try {
-      await authClient.post('/api/user/onboarding', {
+      await authClient.post('/user/onboarding', {
         primaryReason: formData.primaryReason,
         role: formData.role,
         currentTools: formData.currentTools,

--- a/src/components/Parameter.jsx
+++ b/src/components/Parameter.jsx
@@ -92,7 +92,7 @@ const useParameterAsyncValidation = ({
           try {
             const formValues = form.getFieldsValue();
             const response = await getScenarioClient().post(
-              `/api/tools/${toolName}/validate-field`,
+              `/tools/${toolName}/validate-field`,
               {
                 parameter_name: name,
                 value: fieldValue,

--- a/src/components/SearchBar.jsx
+++ b/src/components/SearchBar.jsx
@@ -12,7 +12,7 @@ const useGlossaryData = () => {
   useEffect(() => {
     const getSearchResults = async () => {
       try {
-        const result = await apiClient.get(`/api/glossary/`);
+        const result = await apiClient.get(`/glossary/`);
         setData(result.data);
       } catch (error) {
         console.error(error);

--- a/src/constants/inputEndpoints.json
+++ b/src/constants/inputEndpoints.json
@@ -1,7 +1,0 @@
-{
-  "zone": "/api/inputs/building-properties/zone/geojson",
-  "surroundings": "/api/inputs/building-properties/surroundings/geojson",
-  "streets": "/api/inputs/others/streets/geojson",
-  "dh": "/api/inputs/others/dh/geojson",
-  "dc": "/api/inputs/others/dc/geojson"
-}

--- a/src/features/auth/components/Login/LogoutButton.jsx
+++ b/src/features/auth/components/Login/LogoutButton.jsx
@@ -3,7 +3,7 @@ import { apiClient } from 'lib/api/axios';
 
 const logout = async () => {
   try {
-    const resp = await apiClient.delete('/api/user/logout');
+    const resp = await apiClient.delete('/user/logout');
     console.log('Logout:', resp.data);
     return true;
   } catch (error) {

--- a/src/features/canvas/CLAUDE.md
+++ b/src/features/canvas/CLAUDE.md
@@ -590,7 +590,7 @@ source of truth for card config that the comparison views never read.
 ## Related Files
 - `stores/canvasStore.js` - View state machine, card CRUD, default
   card / map-anchor constants.
-- `hooks/useCanvasData.js` - React Query wrappers for `/api/reports/*`.
+- `hooks/useCanvasData.js` - React Query wrappers for `/reports/*`.
   `useFetchCustomPlot` takes `scenarioContext = { scenarioName, pathwayName?, year? }`;
   pathway-single uses `X-CEA-Child-Scenario` header, others use `X-CEA-Scenario-Name` only.
 - `hooks/useYAxisAlignment.js` - Debounced Plotly y-axis unifier.

--- a/src/features/canvas/api/canvas.js
+++ b/src/features/canvas/api/canvas.js
@@ -1,7 +1,7 @@
 /**
  * Canvas Builder backend client.
  *
- * Thin axios wrappers around the `/api/canvas/*` endpoints (router
+ * Thin axios wrappers around the `/canvas/*` endpoints (router
  * lives in `cea/interfaces/dashboard/api/canvas.py`). Each call
  * carries the active scenario via `X-CEA-*` request headers
  * (preferred by the backend's `CEAScenario` dependency over query
@@ -16,7 +16,7 @@
 import { apiClient, getScenarioClient } from 'lib/api/axios';
 import { scenarioHeaders } from 'lib/api/scenarioContext';
 
-const BASE = '/api/canvas';
+const BASE = '/canvas';
 
 // ── Saved canvases ─────────────────────────────────────────────
 // Reads (list/read) go through getScenarioClient() so they also work

--- a/src/features/canvas/api/canvas.test.js
+++ b/src/features/canvas/api/canvas.test.js
@@ -1,0 +1,119 @@
+import { apiClient, getScenarioClient } from 'lib/api/axios';
+
+import * as canvasApi from './canvas';
+
+// Table-driven regression net for the mechanical /api-prefix strip - also
+// covers `const BASE = '/canvas'` (canvas.js:19) as a single point of truth:
+// if BASE regresses to '/api/canvas', every test in this file fails together.
+vi.mock('lib/api/axios', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+  getScenarioClient: vi.fn(),
+}));
+
+vi.mock('lib/api/scenarioContext', () => ({
+  scenarioHeaders: vi.fn(() => ({ 'X-CEA-Scenario-Name': 'baseline' })),
+}));
+
+const scenarioClient = { get: vi.fn() };
+const ctx = { project: 'my-project', scenario: 'baseline' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getScenarioClient.mockReturnValue(scenarioClient);
+  apiClient.get.mockResolvedValue({ data: {} });
+  apiClient.post.mockResolvedValue({ data: {} });
+  apiClient.put.mockResolvedValue({ data: {} });
+  apiClient.delete.mockResolvedValue({ data: {} });
+  scenarioClient.get.mockResolvedValue({ data: {} });
+});
+
+describe('reads via getScenarioClient (demo-mode-aware)', () => {
+  it('listSavedCanvases -> GET /canvas/', async () => {
+    await canvasApi.listSavedCanvases(ctx);
+    expect(scenarioClient.get).toHaveBeenCalledWith(
+      '/canvas/',
+      expect.any(Object),
+    );
+  });
+
+  it('readSavedCanvas -> GET /canvas/{name}', async () => {
+    await canvasApi.readSavedCanvas({ ...ctx, name: 'my-canvas' });
+    expect(scenarioClient.get).toHaveBeenCalledWith(
+      '/canvas/my-canvas',
+      expect.any(Object),
+    );
+  });
+});
+
+describe('writes via apiClient (demo mode has no write routes)', () => {
+  it('createCanvas -> POST /canvas/', async () => {
+    await canvasApi.createCanvas({ ...ctx, name: 'my-canvas' });
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/canvas/',
+      { name: 'my-canvas' },
+      expect.any(Object),
+    );
+  });
+
+  it('updateSavedCanvas -> PUT /canvas/{name}', async () => {
+    const payload = { layout: {} };
+    await canvasApi.updateSavedCanvas({ ...ctx, name: 'my-canvas', payload });
+    expect(apiClient.put).toHaveBeenCalledWith(
+      '/canvas/my-canvas',
+      payload,
+      expect.any(Object),
+    );
+  });
+
+  it('deleteSavedCanvas -> DELETE /canvas/{name}', async () => {
+    await canvasApi.deleteSavedCanvas({ ...ctx, name: 'my-canvas' });
+    expect(apiClient.delete).toHaveBeenCalledWith(
+      '/canvas/my-canvas',
+      expect.any(Object),
+    );
+  });
+
+  it('duplicateCanvas -> POST /canvas/{name}/duplicate', async () => {
+    await canvasApi.duplicateCanvas({ ...ctx, name: 'my-canvas', as: 'copy' });
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/canvas/my-canvas/duplicate',
+      { name: 'copy' },
+      expect.any(Object),
+    );
+  });
+});
+
+describe('zip export / import', () => {
+  it('exportCanvasZip -> GET /canvas/{name}/export as a blob', async () => {
+    await canvasApi.exportCanvasZip({ ...ctx, name: 'my-canvas' });
+    expect(apiClient.get).toHaveBeenCalledWith(
+      '/canvas/my-canvas/export',
+      expect.objectContaining({ responseType: 'blob' }),
+    );
+  });
+
+  it('importCanvasZip -> POST /canvas/import as multipart form data', async () => {
+    const file = new File(['content'], 'canvas.zip');
+    await canvasApi.importCanvasZip({ ...ctx, file, as: 'renamed' });
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/canvas/import',
+      expect.any(FormData),
+      expect.objectContaining({
+        params: { as: 'renamed' },
+        headers: expect.objectContaining({
+          'Content-Type': 'multipart/form-data',
+        }),
+      }),
+    );
+  });
+});
+
+describe('name encoding at call sites', () => {
+  it('encodes special characters in the canvas name', async () => {
+    await canvasApi.readSavedCanvas({ ...ctx, name: 'a/b c' });
+    expect(scenarioClient.get).toHaveBeenCalledWith(
+      '/canvas/a%2Fb%20c',
+      expect.any(Object),
+    );
+  });
+});

--- a/src/features/canvas/components/CanvasColumn.jsx
+++ b/src/features/canvas/components/CanvasColumn.jsx
@@ -1258,7 +1258,7 @@ const primaryMapDragGripStyle = {
 };
 
 // TODO: drop once these layers exist as real map overlays in the
-// backend `/api/map_layers/` response. They show up in the response
+// backend `/map_layers/` response. They show up in the response
 // but have no overlay data, so picking them yields a card with an
 // empty map. Hidden from the Map picker for now.
 const HIDDEN_MAP_LAYERS = new Set([

--- a/src/features/canvas/components/CanvasPage.jsx
+++ b/src/features/canvas/components/CanvasPage.jsx
@@ -342,7 +342,7 @@ const CanvasPage = () => {
         onCancel={closeKpiPicker}
         onConfirm={handleKpiPickerConfirm}
         project={project}
-        // Picker step-2 hits ``/api/kpis/<id>/parameters`` — option
+        // Picker step-2 hits ``/kpis/<id>/parameters`` — option
         // generators scan the active scenario's output folders, so
         // we forward whichever scenario the anchor's column reads
         // from. Compare-mode anchors (columnIndex >= 0) take the

--- a/src/features/canvas/components/CanvasPlot.jsx
+++ b/src/features/canvas/components/CanvasPlot.jsx
@@ -25,7 +25,7 @@ import { refitCharts } from '../utils/plotResize';
 
 /**
  * Renders a single Plotly plot. Every Canvas Builder plot has a
- * script, so we always fetch via POST /api/reports/plot-custom.
+ * script, so we always fetch via POST /reports/plot-custom.
  *
  * Single render path: parse the HTML, replay the embedded <script>
  * tags inline, post-process the resulting Plotly figures (lift main

--- a/src/features/canvas/components/FeatureCardMap.jsx
+++ b/src/features/canvas/components/FeatureCardMap.jsx
@@ -295,7 +295,7 @@ const FeatureCardMapBody = ({
         if (!isWhatifSync && out[key] !== undefined) continue;
         try {
           const resp = await getScenarioClient().post(
-            `/api/map_layers/${categoryInfo.name}/${layerInfo.name}/${key}/choices`,
+            `/map_layers/${categoryInfo.name}/${layerInfo.name}/${key}/choices`,
             { parameters: out },
             { headers: scenarioHeaders({ project, scenarioName: scenario }) },
           );

--- a/src/features/canvas/components/KpiPicker.jsx
+++ b/src/features/canvas/components/KpiPicker.jsx
@@ -19,7 +19,7 @@
  *            parameters in its yml `source.parameters` block.
  *   Step 2 — only when the chosen KPI has parameters. Renders a
  *            form with one antd `Select` per parameter, populated
- *            from `GET /api/kpis/<id>/parameters` (which calls the
+ *            from `GET /kpis/<id>/parameters` (which calls the
  *            backend's option generators against the active
  *            scenario). Confirm fires
  *            `onConfirm(kpiId, locatorArgsObject)`.

--- a/src/features/canvas/components/NavigatorCard.jsx
+++ b/src/features/canvas/components/NavigatorCard.jsx
@@ -58,7 +58,7 @@ import { CEA_PURPLE, PATHWAY_PRIMARY } from 'constants/theme';
  * Share / Import buttons.
  *
  * There is no Save button and no autosave toggle: every persistable
- * edit hits `PUT /api/canvas/{name}` directly via
+ * edit hits `PUT /canvas/{name}` directly via
  * `useCanvasPersistence`. The expensive plot-data capture pass runs
  * server-side inside `/export` when the user clicks Share.
  *

--- a/src/features/canvas/hooks/useCanvasData.js
+++ b/src/features/canvas/hooks/useCanvasData.js
@@ -53,7 +53,7 @@ export const useFetchSavedCanvases = (project, scenario) =>
   });
 
 // Reads the project store's `scenariosList` directly instead of an
-// independent `/api/project/` fetch - that route requires a session
+// independent `/project/` fetch - that route requires a session
 // and isn't mounted under the demo sub-app, but `scenariosList` is
 // already kept fresh there (seeded on demo entry, refetched on every
 // project load / scenario create-duplicate-delete), so no network
@@ -68,7 +68,7 @@ export const useFetchWhatifs = (project, scenario) =>
   useQuery({
     queryKey: ['reports', 'whatifs', project, scenario],
     queryFn: async () => {
-      const { data } = await getScenarioClient().get('/api/reports/whatifs', {
+      const { data } = await getScenarioClient().get('/reports/whatifs', {
         headers: scenarioHeaders({ project, scenarioName: scenario }),
       });
       return data.whatifs;
@@ -81,7 +81,7 @@ export const useFetchFeatures = () =>
   useQuery({
     queryKey: ['reports', 'features'],
     queryFn: async () => {
-      const { data } = await getScenarioClient().get('/api/reports/features');
+      const { data } = await getScenarioClient().get('/reports/features');
       return data.features;
     },
     staleTime: 5 * 60_000,
@@ -91,7 +91,7 @@ export const useFetchSummary = (project, scenario, feature, whatif) =>
   useQuery({
     queryKey: ['reports', 'summary', project, scenario, feature, whatif],
     queryFn: async () => {
-      const { data } = await getScenarioClient().get('/api/reports/summary', {
+      const { data } = await getScenarioClient().get('/reports/summary', {
         headers: scenarioHeaders({ project, scenarioName: scenario }),
         params: { feature, whatif: whatif || undefined },
       });
@@ -105,7 +105,7 @@ export const useFetchToolParams = (script, scenario, project) =>
   useQuery({
     queryKey: ['tools', script, project, scenario],
     queryFn: async () => {
-      const { data } = await getScenarioClient().get(`/api/tools/${script}`, {
+      const { data } = await getScenarioClient().get(`/tools/${script}`, {
         headers: scenarioHeaders({ project, scenarioName: scenario }),
       });
       return data;
@@ -156,7 +156,7 @@ export const useFetchCustomPlot = (plotConfig, scenarioContext, project) => {
       // eslint-disable-next-line no-unused-vars
       const { scenario: _scenario, ...rest } = plotConfig.parameters || {};
       const { data } = await getScenarioClient().post(
-        '/api/reports/plot-custom',
+        '/reports/plot-custom',
         {
           script: plotConfig.script,
           parameters: serializeParameters(rest),

--- a/src/features/canvas/hooks/useCanvasPersistence.js
+++ b/src/features/canvas/hooks/useCanvasPersistence.js
@@ -2,7 +2,7 @@
  * Autosave hook for the Canvas Builder.
  *
  * Subscribes to the canvas store and flushes a serialised snapshot
- * to the backend's `/api/canvas/{name}` endpoint on a debounced
+ * to the backend's `/canvas/{name}` endpoint on a debounced
  * cadence. Every edit lands in the saved folder directly — there
  * is no temp / draft staging area.
  *
@@ -12,7 +12,7 @@
  * Activation rules:
  *   - No project / scenario selected → do nothing.
  *   - No canvas open (`canvasName == null`)  → do nothing. The
- *     navigator's New-canvas modal calls `POST /api/canvas/`
+ *     navigator's New-canvas modal calls `POST /canvas/`
  *     itself before populating `canvasName`, so the folder always
  *     exists by the time the autosave hook starts targeting it.
  *   - Otherwise: every persistable change fires a 300 ms debounce

--- a/src/features/canvas/hooks/useFetchKpis.js
+++ b/src/features/canvas/hooks/useFetchKpis.js
@@ -1,5 +1,5 @@
 /**
- * React Query wrappers around `GET /api/kpis/...`.
+ * React Query wrappers around `GET /kpis/...`.
  *
  * Five hooks:
  *
@@ -16,7 +16,7 @@
  *
  * - `useFetchKpiSparkline({...})` fans out per-state-year fetches
  *   for pathway-state KPI cards. Currently uses the bulk
- *   ``/api/kpis/?feature=...`` endpoint; per-card ``locatorArgs``
+ *   ``/kpis/?feature=...`` endpoint; per-card ``locatorArgs``
  *   overrides aren't honoured here yet (TODO).
  *
  * - `useFetchKpiRegistry()` fetches the flat KPI catalogue
@@ -78,7 +78,7 @@ export const useFetchKpiValue = ({
     ],
     queryFn: async () => {
       const { data } = await getScenarioClient().get(
-        `/api/kpis/${kpiId}/value`,
+        `/kpis/${kpiId}/value`,
         {
           headers: scenarioHeaders({ project, scenarioName: scenario }),
           params: {
@@ -119,7 +119,7 @@ export const useFetchKpiParameters = ({
     ],
     queryFn: async () => {
       const { data } = await getScenarioClient().get(
-        `/api/kpis/${kpiId}/parameters`,
+        `/kpis/${kpiId}/parameters`,
         {
           headers: scenarioHeaders({ project, scenarioName: scenario }),
           params: {
@@ -143,11 +143,11 @@ export const useFetchKpiParameters = ({
  * the polyline at gaps. ``null`` points means the inputs are not
  * yet sufficient to fetch (no project, no state-years, etc.).
  *
- * NOTE: still hits the bulk ``/api/kpis/?feature=...`` endpoint
+ * NOTE: still hits the bulk ``/kpis/?feature=...`` endpoint
  * and ignores per-card ``locatorArgs`` overrides — a sparkline on
  * a card with a non-default ``panel_type`` will currently show
  * the yml-default series. To fix, switch each year's query to the
- * single-KPI ``/api/kpis/<id>/value`` endpoint with the card's
+ * single-KPI ``/kpis/<id>/value`` endpoint with the card's
  * args forwarded.
  */
 export const useFetchKpiSparkline = ({
@@ -186,7 +186,7 @@ export const useFetchKpiSparkline = ({
     queries: yearsAndPaths.map(({ year, scenario }) => ({
       queryKey: [KPIS_QUERY_ROOT, project, scenario, feature, whatif ?? null],
       queryFn: async () => {
-        const { data } = await getScenarioClient().get('/api/kpis/', {
+        const { data } = await getScenarioClient().get('/kpis/', {
           headers: scenarioHeaders({
             project,
             scenarioName: parentScenario,
@@ -230,7 +230,7 @@ export const useFetchKpiRegistry = () =>
   useQuery({
     queryKey: ['kpi-registry'],
     queryFn: async () => {
-      const { data } = await getScenarioClient().get('/api/kpis/registry');
+      const { data } = await getScenarioClient().get('/kpis/registry');
       return data;
     },
     staleTime: 60 * 60_000, // 1h

--- a/src/features/canvas/hooks/useFetchKpis.js
+++ b/src/features/canvas/hooks/useFetchKpis.js
@@ -77,16 +77,13 @@ export const useFetchKpiValue = ({
       whatif ?? null,
     ],
     queryFn: async () => {
-      const { data } = await getScenarioClient().get(
-        `/kpis/${kpiId}/value`,
-        {
-          headers: scenarioHeaders({ project, scenarioName: scenario }),
-          params: {
-            locator_args: argsKey || undefined,
-            whatif: whatif || undefined,
-          },
+      const { data } = await getScenarioClient().get(`/kpis/${kpiId}/value`, {
+        headers: scenarioHeaders({ project, scenarioName: scenario }),
+        params: {
+          locator_args: argsKey || undefined,
+          whatif: whatif || undefined,
         },
-      );
+      });
       return data;
     },
     enabled: !!project && !!scenario && !!kpiId,

--- a/src/features/canvas/stores/canvasStore.js
+++ b/src/features/canvas/stores/canvasStore.js
@@ -361,7 +361,7 @@ export const useCanvasStore = create((set, get) => ({
   // Display name of the currently-open canvas — also the on-disk
   // folder under `<scenario>/outputs/canvas/<name>/`. Set when the
   // user opens a saved canvas (load), creates one via the
-  // navigator's "Create new canvas" modal (POST /api/canvas/), or
+  // navigator's "Create new canvas" modal (POST /canvas/), or
   // imports a zip. `null` only in the empty entry state (between
   // a Start Over and the next create / open). The persistence
   // hook keys every debounced PUT off this name.

--- a/src/features/dashboard/components/Dashboard/Dashboard.jsx
+++ b/src/features/dashboard/components/Dashboard/Dashboard.jsx
@@ -174,7 +174,7 @@ const useDashboardData = () => {
 
   const fetchDashboards = async () => {
     try {
-      const resp = await apiClient.get(`/api/dashboards/`);
+      const resp = await apiClient.get(`/dashboards/`);
       setDashboards(resp.data);
     } catch (error) {
       console.error(error);
@@ -182,7 +182,7 @@ const useDashboardData = () => {
   };
   const fetchCategories = async () => {
     try {
-      const resp = await apiClient.get(`/api/dashboards/plot-categories`);
+      const resp = await apiClient.get(`/dashboards/plot-categories`);
       setCategories(resp.data);
     } catch (error) {
       console.error(error);

--- a/src/features/dashboard/components/Dashboard/Modals.jsx
+++ b/src/features/dashboard/components/Dashboard/Modals.jsx
@@ -25,7 +25,7 @@ export const ModalNewDashboard = ({
         setConfirmLoading(true);
         console.log('Received values of form: ', values);
         apiClient
-          .post(`/api/dashboards/`, values)
+          .post(`/dashboards/`, values)
           .then((response) => {
             if (response) {
               console.log(response.data);
@@ -134,7 +134,7 @@ export const ModalDuplicateDashboard = ({
         setConfirmLoading(true);
         console.log('Received values of form: ', values);
         apiClient
-          .post(`/api/dashboards/duplicate`, {
+          .post(`/dashboards/duplicate`, {
             ...values,
             dashboard_index: dashIndex,
           })
@@ -220,7 +220,7 @@ export const ModalSetScenario = ({ fetchDashboards, dashIndex }) => {
         setConfirmLoading(true);
         console.log('Received values of form: ', values);
         apiClient
-          .patch(`/api/dashboards/${dashIndex}`, values)
+          .patch(`/dashboards/${dashIndex}`, values)
           .then((response) => {
             if (response) {
               console.log(response.data);
@@ -243,7 +243,7 @@ export const ModalSetScenario = ({ fetchDashboards, dashIndex }) => {
 
   useEffect(() => {
     if (visible.setScenario) {
-      apiClient.get(`/api/project/`).then((response) => {
+      apiClient.get(`/project/`).then((response) => {
         const { scenario, scenarios } = response.data;
         setScenarios({
           type: 'ScenarioNameParameter',
@@ -292,7 +292,7 @@ export const ModalDeleteDashboard = ({
   const handleOk = () => {
     setConfirmLoading(true);
     apiClient
-      .delete(`/api/dashboards/${dashIndex}`)
+      .delete(`/dashboards/${dashIndex}`)
       .then((response) => {
         if (response) {
           console.log(response.data);
@@ -350,7 +350,7 @@ const ModalAddPlotTemplate = ({
   const getParameters = async (scenario) => {
     try {
       const params = await apiClient.get(
-        `/api/dashboards/plot-categories/${
+        `/dashboards/plot-categories/${
           category.category
         }/plots/${category.plot_id}/parameters`,
         scenario ? { params: { scenario } } : {},
@@ -368,7 +368,7 @@ const ModalAddPlotTemplate = ({
         setConfirmLoading(true);
         console.log('Received values of form: ', values);
         apiClient
-          .put(`/api/dashboards/${dashIndex}/plots/${activePlotRef.current}`, {
+          .put(`/dashboards/${dashIndex}/plots/${activePlotRef.current}`, {
             ...category,
             parameters: values,
           })
@@ -547,7 +547,7 @@ export const ModalEditParameters = ({
   const getParameters = async (scenario) => {
     try {
       const params = await apiClient.get(
-        `/api/dashboards/${dashIndex}/plots/${
+        `/dashboards/${dashIndex}/plots/${
           activePlotRef.current
         }/parameters`,
         scenario ? { params: { scenario } } : {},
@@ -565,7 +565,7 @@ export const ModalEditParameters = ({
         setConfirmLoading(true);
         console.log('Received values of form: ', values);
         apiClient
-          .put(`/api/dashboards/${dashIndex}/plots/${activePlotRef.current}`, {
+          .put(`/dashboards/${dashIndex}/plots/${activePlotRef.current}`, {
             parameters: values,
           })
           .then((response) => {
@@ -651,7 +651,7 @@ export const ModalDeletePlot = ({
   const handleOk = () => {
     setConfirmLoading(true);
     apiClient
-      .delete(`/api/dashboards/${dashIndex}/plots/${activePlotRef.current}`)
+      .delete(`/dashboards/${dashIndex}/plots/${activePlotRef.current}`)
       .then((response) => {
         if (response) {
           console.log(response.data);
@@ -755,7 +755,7 @@ export const ModalPlotFiles = ({ dashIndex, activePlotRef }) => {
       try {
         setLoading(true);
         const { data } = await apiClient.get(
-          `/api/dashboards/${dashIndex}/plots/${
+          `/dashboards/${dashIndex}/plots/${
             activePlotRef.current
           }/input-files`,
         );

--- a/src/features/database-editor/CLAUDE.md
+++ b/src/features/database-editor/CLAUDE.md
@@ -1,6 +1,6 @@
 # Database Editor - Claude Code Guide
 
-> **Backend Data Format:** See [DATA_FORMAT.md](./DATA_FORMAT.md) for detailed explanation of the JSON response structure from `/api/inputs/databases` endpoint.
+> **Backend Data Format:** See [DATA_FORMAT.md](./DATA_FORMAT.md) for detailed explanation of the JSON response structure from `/inputs/databases` endpoint.
 
 ## CRITICAL RULES - Read First
 

--- a/src/features/database-editor/DATA_FORMAT.md
+++ b/src/features/database-editor/DATA_FORMAT.md
@@ -1,6 +1,6 @@
 # Database Backend Response Format
 
-This document describes the JSON data structure returned by `/api/inputs/databases` endpoint.
+This document describes the JSON data structure returned by `/inputs/databases` endpoint.
 
 ## Top-Level Structure
 

--- a/src/features/database-editor/components/export-button.jsx
+++ b/src/features/database-editor/components/export-button.jsx
@@ -28,7 +28,7 @@ export const ExportDatabaseButton = () => {
         setLoading(true);
         try {
           const response = await apiClient.get(
-            '/api/inputs/databases/download',
+            '/inputs/databases/download',
             { responseType: 'blob', headers: activeScenarioHeaders() },
           );
 

--- a/src/features/database-editor/components/import-button.jsx
+++ b/src/features/database-editor/components/import-button.jsx
@@ -57,7 +57,7 @@ const ImportDatabaseModal = ({ visible, setVisible }) => {
     formData.append('file', fileList[0].originFileObj);
 
     try {
-      await apiClient.post(`/api/inputs/databases/upload`, formData, {
+      await apiClient.post(`/inputs/databases/upload`, formData, {
         headers: {
           'Content-Type': 'multipart/form-data',
           ...activeScenarioHeaders(),

--- a/src/features/database-editor/components/save-button.jsx
+++ b/src/features/database-editor/components/save-button.jsx
@@ -29,7 +29,7 @@ export const SaveDatabaseButton = () => {
     setModalVisible(true);
     try {
       const { data: databasesData } = useDatabaseEditorStore.getState();
-      await apiClient.put(`/api/inputs/databases`, databasesData, {
+      await apiClient.put(`/inputs/databases`, databasesData, {
         headers: activeScenarioHeaders(),
       });
       setSuccess(true);

--- a/src/features/database-editor/stores/databaseEditorStore.js
+++ b/src/features/database-editor/stores/databaseEditorStore.js
@@ -49,7 +49,7 @@ const useDatabaseEditorStore = create((set, get) => ({
 
     set({ databaseValidation: { status: 'checking', message: null } });
     try {
-      await getScenarioClient().get('/api/inputs/databases/check', {
+      await getScenarioClient().get('/inputs/databases/check', {
         headers: activeScenarioHeaders(),
       });
       set({ databaseValidation: { status: 'valid', message: null } });
@@ -77,7 +77,7 @@ const useDatabaseEditorStore = create((set, get) => ({
   initDatabaseState: async () => {
     set({ data: {}, status: { status: FETCHING_STATUS }, isEmpty: false });
     try {
-      const { data } = await getScenarioClient().get('/api/inputs/databases', {
+      const { data } = await getScenarioClient().get('/inputs/databases', {
         headers: activeScenarioHeaders(),
       });
       set({
@@ -125,7 +125,7 @@ const useDatabaseEditorStore = create((set, get) => ({
 
     try {
       set({ status: { status: SAVING_STATUS } });
-      await apiClient.put('/api/inputs/databases', data, {
+      await apiClient.put('/inputs/databases', data, {
         headers: activeScenarioHeaders(),
       });
       set({ status: { status: SUCCESS_STATUS }, changes: [] });
@@ -150,7 +150,7 @@ const useDatabaseEditorStore = create((set, get) => ({
 
   fetchDatabaseSchema: async (params) => {
     try {
-      const response = await getScenarioClient().get('/api/databases/schema', {
+      const response = await getScenarioClient().get('/databases/schema', {
         params,
       });
       set({ schema: response.data });

--- a/src/features/map/components/Map/Layers/Selectors/Choice.jsx
+++ b/src/features/map/components/Map/Layers/Selectors/Choice.jsx
@@ -41,7 +41,7 @@ const getChoices = async (
   childScenario = null,
 ) => {
   const resp = await getScenarioClient().post(
-    `/api/map_layers/${layerCategory}/${layerName}/${parameterName}/choices`,
+    `/map_layers/${layerCategory}/${layerName}/${parameterName}/choices`,
     { parameters },
     { headers: scenarioHeaders({ project, scenarioName, childScenario }) },
   );

--- a/src/features/map/components/Map/Layers/Selectors/DeleteChoiceModal.jsx
+++ b/src/features/map/components/Map/Layers/Selectors/DeleteChoiceModal.jsx
@@ -34,7 +34,7 @@ const DeleteChoiceModal = ({
     setLoading(true);
     try {
       await apiClient.post(
-        `/api/map_layers/${layerCategory}/${layerName}/${parameterName}/choice/delete`,
+        `/map_layers/${layerCategory}/${layerName}/${parameterName}/choice/delete`,
         { value },
         { headers: scenarioHeaders({ project, scenarioName, childScenario }) },
       );

--- a/src/features/map/components/Map/Layers/Selectors/Slider.jsx
+++ b/src/features/map/components/Map/Layers/Selectors/Slider.jsx
@@ -20,7 +20,7 @@ const getRange = async (
   childScenario = null,
 ) => {
   const resp = await getScenarioClient().post(
-    `/api/map_layers/${layerCategory}/${layerName}/${parameterName}/range`,
+    `/map_layers/${layerCategory}/${layerName}/${parameterName}/range`,
     { parameters },
     { headers: scenarioHeaders({ project, scenarioName, childScenario }) },
   );

--- a/src/features/map/hooks/index.js
+++ b/src/features/map/hooks/index.js
@@ -97,7 +97,7 @@ export const useFetchBuildingsFromPath = (onFetchedBuildings) => {
     }
 
     try {
-      const resp = await apiClient.get(`/api/geometry/buildings`, {
+      const resp = await apiClient.get(`/geometry/buildings`, {
         params: {
           path,
         },
@@ -127,7 +127,7 @@ export const useFetchBuildings = (onFetchedBuildings) => {
     setError(null);
     setFetching(true);
     try {
-      const resp = await apiClient.get(`/api/geometry/buildings`, {
+      const resp = await apiClient.get(`/geometry/buildings`, {
         params: {
           generate: true,
           polygon: JSON.stringify(polygon),

--- a/src/features/map/hooks/map-layers.js
+++ b/src/features/map/hooks/map-layers.js
@@ -195,7 +195,7 @@ export const useMapLegends = () => {
 
 const fetchMapLayer = async (category, layer_name, body, headers = {}) => {
   const resp = await getScenarioClient().post(
-    `/api/map_layers/${category}/${layer_name}/generate`,
+    `/map_layers/${category}/${layer_name}/generate`,
     body,
     { headers },
   );

--- a/src/features/pathway/CLAUDE.md
+++ b/src/features/pathway/CLAUDE.md
@@ -160,12 +160,16 @@ const { data } = await apiClient.post(url, body, {
   headers: activeScenarioHeaders(),
 });
 ```
-Exception: `fetchStateFolderPath` targets a project endpoint that reads
-`project` + `scenario_name` as query params — documented in its comment.
+Exception: `fetchStateFolderPath` passes `project`/`scenarioName` via
+`scenarioHeaders()` instead of `activeScenarioHeaders()`, since it may be
+called before a scenario is active; only `pathway_name` and `year` go in
+the query params (the backend's `/project/state-folder` route resolves
+project/scenario from headers via the `CEAScenario` dependency, same as
+every other route).
 
 ## Related Files
 - `api.js` - Dedicated pathway API client helpers. Every call uses
-  `activeScenarioHeaders()` except `fetchStateFolderPath` (query params).
+  `activeScenarioHeaders()` except `fetchStateFolderPath` (`scenarioHeaders()`).
 - `hooks/usePathwayOverview.js` - React Query wrapper around `fetchPathwayOverview` plus the `useHasSimulatedPathway` boolean derivative.
 - `components/PathwayPanel.jsx` - Stacked-lane panel, shared ruler, inspector, and editor workflows.
 - `../project/components/ProjectOverlay.jsx` - Bottom-panel mounting point and transition sizing.

--- a/src/features/pathway/api.js
+++ b/src/features/pathway/api.js
@@ -7,14 +7,14 @@ import {
 const encodePathwayName = (pathwayName) => encodeURIComponent(pathwayName);
 
 export const fetchPathways = async () => {
-  const { data } = await getScenarioClient().get('/api/pathways/', {
+  const { data } = await getScenarioClient().get('/pathways/', {
     headers: activeScenarioHeaders(),
   });
   return data?.pathways ?? [];
 };
 
 export const fetchPathwayOverview = async () => {
-  const { data } = await getScenarioClient().get('/api/pathways/overview', {
+  const { data } = await getScenarioClient().get('/pathways/overview', {
     headers: activeScenarioHeaders(),
   });
   return data;
@@ -22,7 +22,7 @@ export const fetchPathwayOverview = async () => {
 
 export const createPathway = async (pathwayName) => {
   const { data } = await apiClient.post(
-    '/api/pathways/',
+    '/pathways/',
     { pathway_name: pathwayName },
     { headers: activeScenarioHeaders() },
   );
@@ -31,7 +31,7 @@ export const createPathway = async (pathwayName) => {
 
 export const fetchPathwayTimeline = async (pathwayName) => {
   const { data } = await getScenarioClient().get(
-    `/api/pathways/${encodePathwayName(pathwayName)}/timeline`,
+    `/pathways/${encodePathwayName(pathwayName)}/timeline`,
     { headers: activeScenarioHeaders() },
   );
   return data;
@@ -39,7 +39,7 @@ export const fetchPathwayTimeline = async (pathwayName) => {
 
 export const addPathwayYear = async (pathwayName, year) => {
   const { data } = await apiClient.post(
-    `/api/pathways/${encodePathwayName(pathwayName)}/years/${year}`,
+    `/pathways/${encodePathwayName(pathwayName)}/years/${year}`,
     undefined,
     { headers: activeScenarioHeaders() },
   );
@@ -48,7 +48,7 @@ export const addPathwayYear = async (pathwayName, year) => {
 
 export const deletePathwayYear = async (pathwayName, year) => {
   const { data } = await apiClient.delete(
-    `/api/pathways/${encodePathwayName(pathwayName)}/years/${year}`,
+    `/pathways/${encodePathwayName(pathwayName)}/years/${year}`,
     { headers: activeScenarioHeaders() },
   );
   return data;
@@ -56,7 +56,7 @@ export const deletePathwayYear = async (pathwayName, year) => {
 
 export const validatePathwayLog = async (pathwayName) => {
   const { data } = await apiClient.post(
-    `/api/pathways/${encodePathwayName(pathwayName)}/validate-log`,
+    `/pathways/${encodePathwayName(pathwayName)}/validate-log`,
     undefined,
     { headers: activeScenarioHeaders() },
   );
@@ -65,7 +65,7 @@ export const validatePathwayLog = async (pathwayName) => {
 
 export const fetchYearEditorOptions = async (pathwayName, year) => {
   const { data } = await getScenarioClient().get(
-    `/api/pathways/${encodePathwayName(pathwayName)}/years/${year}/editor-options`,
+    `/pathways/${encodePathwayName(pathwayName)}/years/${year}/editor-options`,
     { headers: activeScenarioHeaders() },
   );
   return data;
@@ -78,7 +78,7 @@ export const saveBuildingEvents = async (
   demolishedBuildings,
 ) => {
   const { data } = await apiClient.post(
-    `/api/pathways/${encodePathwayName(pathwayName)}/years/${year}/building-events`,
+    `/pathways/${encodePathwayName(pathwayName)}/years/${year}/building-events`,
     { new_buildings: newBuildings, demolished_buildings: demolishedBuildings },
     { headers: activeScenarioHeaders() },
   );
@@ -91,7 +91,7 @@ export const applyTemplatesToYear = async (
   templateNames,
 ) => {
   const { data } = await apiClient.post(
-    `/api/pathways/${encodePathwayName(pathwayName)}/years/${year}/apply-templates`,
+    `/pathways/${encodePathwayName(pathwayName)}/years/${year}/apply-templates`,
     { template_names: templateNames },
     { headers: activeScenarioHeaders() },
   );
@@ -100,7 +100,7 @@ export const applyTemplatesToYear = async (
 
 export const saveYearYaml = async (pathwayName, year, rawYaml) => {
   const { data } = await apiClient.put(
-    `/api/pathways/${encodePathwayName(pathwayName)}/years/${year}/yaml`,
+    `/pathways/${encodePathwayName(pathwayName)}/years/${year}/yaml`,
     { raw_yaml: rawYaml },
     { headers: activeScenarioHeaders() },
   );
@@ -108,7 +108,7 @@ export const saveYearYaml = async (pathwayName, year, rawYaml) => {
 };
 
 export const fetchInterventionTemplates = async () => {
-  const { data } = await getScenarioClient().get('/api/pathways/templates', {
+  const { data } = await getScenarioClient().get('/pathways/templates', {
     headers: activeScenarioHeaders(),
   });
   return {
@@ -119,7 +119,7 @@ export const fetchInterventionTemplates = async () => {
 
 export const deleteInterventionTemplate = async (templateName) => {
   const { data } = await apiClient.delete(
-    `/api/pathways/templates/${encodeURIComponent(templateName)}`,
+    `/pathways/templates/${encodeURIComponent(templateName)}`,
     { headers: activeScenarioHeaders() },
   );
   return data;
@@ -127,7 +127,7 @@ export const deleteInterventionTemplate = async (templateName) => {
 
 export const fetchInterventionTemplate = async (templateName) => {
   const { data } = await getScenarioClient().get(
-    `/api/pathways/templates/${encodeURIComponent(templateName)}`,
+    `/pathways/templates/${encodeURIComponent(templateName)}`,
     { headers: activeScenarioHeaders() },
   );
   return data;
@@ -135,7 +135,7 @@ export const fetchInterventionTemplate = async (templateName) => {
 
 export const fetchTemplateUsage = async (templateName) => {
   const { data } = await getScenarioClient().get(
-    `/api/pathways/templates/${encodeURIComponent(templateName)}/usage`,
+    `/pathways/templates/${encodeURIComponent(templateName)}/usage`,
     { headers: activeScenarioHeaders() },
   );
   return data?.usage ?? [];
@@ -143,7 +143,7 @@ export const fetchTemplateUsage = async (templateName) => {
 
 export const preSaveDefineTemplateConfig = async (configPayload) => {
   await apiClient.post(
-    '/api/tools/pathway-intervention-templates-define/save-config',
+    '/tools/pathway-intervention-templates-define/save-config',
     configPayload,
     { headers: activeScenarioHeaders() },
   );
@@ -151,7 +151,7 @@ export const preSaveDefineTemplateConfig = async (configPayload) => {
 
 export const preSaveSimulatePathwayConfig = async (pathwayName) => {
   await apiClient.post(
-    '/api/tools/pathway-simulations/save-config',
+    '/tools/pathway-simulations/save-config',
     { 'existing-pathway-name': pathwayName },
     { headers: activeScenarioHeaders() },
   );
@@ -159,7 +159,7 @@ export const preSaveSimulatePathwayConfig = async (pathwayName) => {
 
 export const preSaveBuildingEventsConfig = async (pathwayNames, year) => {
   await apiClient.post(
-    '/api/tools/pathway-update-building-events/save-config',
+    '/tools/pathway-update-building-events/save-config',
     {
       'existing-pathway-names': pathwayNames.join(', '),
       'year-of-state': year,
@@ -172,7 +172,7 @@ export const preSaveBuildingEventsConfig = async (pathwayNames, year) => {
 
 export const fetchStateGeojson = async (pathwayName, year) => {
   const { data } = await getScenarioClient().get(
-    `/api/pathways/${encodePathwayName(pathwayName)}/years/${year}/geojson`,
+    `/pathways/${encodePathwayName(pathwayName)}/years/${year}/geojson`,
     { headers: activeScenarioHeaders() },
   );
   return data;
@@ -183,7 +183,7 @@ export const fetchBuildingLifecycle = async (buildingName, pathwayNames) => {
     ? { pathways: pathwayNames.join(',') }
     : {};
   const { data } = await getScenarioClient().get(
-    `/api/pathways/building-lifecycle/${encodeURIComponent(buildingName)}`,
+    `/pathways/building-lifecycle/${encodeURIComponent(buildingName)}`,
     { params: pathwayParams, headers: activeScenarioHeaders() },
   );
   return data;
@@ -195,7 +195,7 @@ export const fetchStateFolderPath = async (
   project,
   scenarioName,
 ) => {
-  const { data } = await getScenarioClient().get('/api/project/state-folder', {
+  const { data } = await getScenarioClient().get('/project/state-folder', {
     headers: scenarioHeaders({ project, scenarioName }),
     params: { pathway_name: pathwayName, year },
   });
@@ -204,7 +204,7 @@ export const fetchStateFolderPath = async (
 
 export const validateStateYear = async (pathwayName, year) => {
   const { data } = await apiClient.post(
-    `/api/pathways/${encodePathwayName(pathwayName)}/years/${year}/validate-state`,
+    `/pathways/${encodePathwayName(pathwayName)}/years/${year}/validate-state`,
     undefined,
     { headers: activeScenarioHeaders() },
   );

--- a/src/features/pathway/api.test.js
+++ b/src/features/pathway/api.test.js
@@ -1,0 +1,242 @@
+import { apiClient, getScenarioClient } from 'lib/api/axios';
+
+import * as pathwayApi from './api';
+
+// Table-driven regression net for the mechanical /api-prefix strip: every
+// exported function here just builds a URL and delegates to one of two
+// clients. A future edit that reintroduces a stray '/api' segment, or drops
+// one, fails here instead of at runtime.
+vi.mock('lib/api/axios', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), put: vi.fn(), delete: vi.fn() },
+  getScenarioClient: vi.fn(),
+}));
+
+vi.mock('lib/api/scenarioContext', () => ({
+  activeScenarioHeaders: vi.fn(() => ({ 'X-CEA-Scenario-Name': 'baseline' })),
+  scenarioHeaders: vi.fn(() => ({ 'X-CEA-Project': 'my-project' })),
+}));
+
+const scenarioClient = { get: vi.fn() };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getScenarioClient.mockReturnValue(scenarioClient);
+  apiClient.get.mockResolvedValue({ data: {} });
+  apiClient.post.mockResolvedValue({ data: {} });
+  apiClient.put.mockResolvedValue({ data: {} });
+  apiClient.delete.mockResolvedValue({ data: {} });
+  scenarioClient.get.mockResolvedValue({ data: {} });
+});
+
+describe('reads via getScenarioClient (demo-mode-aware)', () => {
+  it('fetchPathways -> GET /pathways/', async () => {
+    await pathwayApi.fetchPathways();
+    expect(scenarioClient.get).toHaveBeenCalledWith(
+      '/pathways/',
+      expect.any(Object),
+    );
+  });
+
+  it('fetchPathwayOverview -> GET /pathways/overview', async () => {
+    await pathwayApi.fetchPathwayOverview();
+    expect(scenarioClient.get).toHaveBeenCalledWith(
+      '/pathways/overview',
+      expect.any(Object),
+    );
+  });
+
+  it('fetchPathwayTimeline -> GET /pathways/{name}/timeline', async () => {
+    await pathwayApi.fetchPathwayTimeline('demo');
+    expect(scenarioClient.get).toHaveBeenCalledWith(
+      '/pathways/demo/timeline',
+      expect.any(Object),
+    );
+  });
+
+  it('fetchYearEditorOptions -> GET /pathways/{name}/years/{year}/editor-options', async () => {
+    await pathwayApi.fetchYearEditorOptions('demo', 2030);
+    expect(scenarioClient.get).toHaveBeenCalledWith(
+      '/pathways/demo/years/2030/editor-options',
+      expect.any(Object),
+    );
+  });
+
+  it('fetchInterventionTemplates -> GET /pathways/templates', async () => {
+    await pathwayApi.fetchInterventionTemplates();
+    expect(scenarioClient.get).toHaveBeenCalledWith(
+      '/pathways/templates',
+      expect.any(Object),
+    );
+  });
+
+  it('fetchInterventionTemplate -> GET /pathways/templates/{name}', async () => {
+    await pathwayApi.fetchInterventionTemplate('my-template');
+    expect(scenarioClient.get).toHaveBeenCalledWith(
+      '/pathways/templates/my-template',
+      expect.any(Object),
+    );
+  });
+
+  it('fetchTemplateUsage -> GET /pathways/templates/{name}/usage', async () => {
+    await pathwayApi.fetchTemplateUsage('my-template');
+    expect(scenarioClient.get).toHaveBeenCalledWith(
+      '/pathways/templates/my-template/usage',
+      expect.any(Object),
+    );
+  });
+
+  it('fetchStateGeojson -> GET /pathways/{name}/years/{year}/geojson', async () => {
+    await pathwayApi.fetchStateGeojson('demo', 2030);
+    expect(scenarioClient.get).toHaveBeenCalledWith(
+      '/pathways/demo/years/2030/geojson',
+      expect.any(Object),
+    );
+  });
+
+  it('fetchBuildingLifecycle -> GET /pathways/building-lifecycle/{building}', async () => {
+    await pathwayApi.fetchBuildingLifecycle('B1', ['demo']);
+    expect(scenarioClient.get).toHaveBeenCalledWith(
+      '/pathways/building-lifecycle/B1',
+      expect.objectContaining({ params: { pathways: 'demo' } }),
+    );
+  });
+
+  it('fetchStateFolderPath -> GET /project/state-folder', async () => {
+    await pathwayApi.fetchStateFolderPath('demo', 2030, 'proj', 'baseline');
+    expect(scenarioClient.get).toHaveBeenCalledWith(
+      '/project/state-folder',
+      expect.objectContaining({
+        params: { pathway_name: 'demo', year: 2030 },
+      }),
+    );
+  });
+});
+
+describe('writes via apiClient (always the real backend, never demo)', () => {
+  it('createPathway -> POST /pathways/', async () => {
+    await pathwayApi.createPathway('demo');
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/pathways/',
+      { pathway_name: 'demo' },
+      expect.any(Object),
+    );
+  });
+
+  it('addPathwayYear -> POST /pathways/{name}/years/{year}', async () => {
+    await pathwayApi.addPathwayYear('demo', 2030);
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/pathways/demo/years/2030',
+      undefined,
+      expect.any(Object),
+    );
+  });
+
+  it('deletePathwayYear -> DELETE /pathways/{name}/years/{year}', async () => {
+    await pathwayApi.deletePathwayYear('demo', 2030);
+    expect(apiClient.delete).toHaveBeenCalledWith(
+      '/pathways/demo/years/2030',
+      expect.any(Object),
+    );
+  });
+
+  it('validatePathwayLog -> POST /pathways/{name}/validate-log', async () => {
+    await pathwayApi.validatePathwayLog('demo');
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/pathways/demo/validate-log',
+      undefined,
+      expect.any(Object),
+    );
+  });
+
+  it('saveBuildingEvents -> POST /pathways/{name}/years/{year}/building-events', async () => {
+    await pathwayApi.saveBuildingEvents('demo', 2030, ['B1'], ['B2']);
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/pathways/demo/years/2030/building-events',
+      { new_buildings: ['B1'], demolished_buildings: ['B2'] },
+      expect.any(Object),
+    );
+  });
+
+  it('applyTemplatesToYear -> POST /pathways/{name}/years/{year}/apply-templates', async () => {
+    await pathwayApi.applyTemplatesToYear('demo', 2030, ['t1']);
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/pathways/demo/years/2030/apply-templates',
+      { template_names: ['t1'] },
+      expect.any(Object),
+    );
+  });
+
+  it('saveYearYaml -> PUT /pathways/{name}/years/{year}/yaml', async () => {
+    await pathwayApi.saveYearYaml('demo', 2030, 'raw: yaml');
+    expect(apiClient.put).toHaveBeenCalledWith(
+      '/pathways/demo/years/2030/yaml',
+      { raw_yaml: 'raw: yaml' },
+      expect.any(Object),
+    );
+  });
+
+  it('deleteInterventionTemplate -> DELETE /pathways/templates/{name}', async () => {
+    await pathwayApi.deleteInterventionTemplate('my-template');
+    expect(apiClient.delete).toHaveBeenCalledWith(
+      '/pathways/templates/my-template',
+      expect.any(Object),
+    );
+  });
+
+  it('preSaveDefineTemplateConfig -> POST /tools/pathway-intervention-templates-define/save-config', async () => {
+    await pathwayApi.preSaveDefineTemplateConfig({ a: 1 });
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/tools/pathway-intervention-templates-define/save-config',
+      { a: 1 },
+      expect.any(Object),
+    );
+  });
+
+  it('preSaveSimulatePathwayConfig -> POST /tools/pathway-simulations/save-config', async () => {
+    await pathwayApi.preSaveSimulatePathwayConfig('demo');
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/tools/pathway-simulations/save-config',
+      { 'existing-pathway-name': 'demo' },
+      expect.any(Object),
+    );
+  });
+
+  it('preSaveBuildingEventsConfig -> POST /tools/pathway-update-building-events/save-config', async () => {
+    await pathwayApi.preSaveBuildingEventsConfig(['demo'], 2030);
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/tools/pathway-update-building-events/save-config',
+      expect.objectContaining({
+        'existing-pathway-names': 'demo',
+        'year-of-state': 2030,
+      }),
+      expect.any(Object),
+    );
+  });
+
+  it('validateStateYear -> POST /pathways/{name}/years/{year}/validate-state', async () => {
+    await pathwayApi.validateStateYear('demo', 2030);
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/pathways/demo/years/2030/validate-state',
+      undefined,
+      expect.any(Object),
+    );
+  });
+});
+
+describe('encodePathwayName / encodeURIComponent at call sites', () => {
+  it('encodes slashes and spaces in a pathway name before building the URL', async () => {
+    await pathwayApi.fetchPathwayTimeline('has space/slash');
+    expect(scenarioClient.get).toHaveBeenCalledWith(
+      '/pathways/has%20space%2Fslash/timeline',
+      expect.any(Object),
+    );
+  });
+
+  it('encodes special characters in a template name', async () => {
+    await pathwayApi.fetchInterventionTemplate('a/b c');
+    expect(scenarioClient.get).toHaveBeenCalledWith(
+      '/pathways/templates/a%2Fb%20c',
+      expect.any(Object),
+    );
+  });
+});

--- a/src/features/project/components/Cards/MapLayersCard/store.jsx
+++ b/src/features/project/components/Cards/MapLayersCard/store.jsx
@@ -12,7 +12,7 @@ export const MAP_LAYER_CATEGORIES_QUERY_KEY = ['map-layer-categories'];
 
 export const fetchMapLayerCategories = async () => {
   try {
-    const { data } = await getScenarioClient().get('/api/map_layers');
+    const { data } = await getScenarioClient().get('/map_layers');
     return data;
   } catch (err) {
     console.error(err);

--- a/src/features/project/components/Cards/OverviewCard/ScenarioRow.jsx
+++ b/src/features/project/components/Cards/OverviewCard/ScenarioRow.jsx
@@ -106,7 +106,7 @@ const ScenarioOption = ({ scenarioName, onDelete }) => {
   );
 };
 
-// Demo mode's scenario switcher: no `/api/project/*` writes (that requires
+// Demo mode's scenario switcher: no `/project/*` writes (that requires
 // a session), so switching just repoints the demo id + project store's
 // scenario field directly. Every read hook keys its React Query cache off
 // `useProjectStore`'s `scenario` value, so this alone is enough to refetch

--- a/src/features/project/components/modals/DeleteProjectModal.jsx
+++ b/src/features/project/components/modals/DeleteProjectModal.jsx
@@ -21,7 +21,7 @@ const DeleteProjectModal = ({ visible, setVisible, project }) => {
   const onClick = async () => {
     setLoading(true);
     try {
-      await apiClient.delete(`/api/project/`, {
+      await apiClient.delete(`/project/`, {
         headers: scenarioHeaders({ project }),
       });
       setVisible(false);

--- a/src/features/project/components/modals/DuplicatePathwayModal.jsx
+++ b/src/features/project/components/modals/DuplicatePathwayModal.jsx
@@ -26,7 +26,7 @@ const DuplicatePathwayModal = ({
     setLoading(true);
     try {
       await apiClient.post(
-        `/api/pathways/${encodeURIComponent(currentPathwayName)}/duplicate`,
+        `/pathways/${encodeURIComponent(currentPathwayName)}/duplicate`,
         { name: values.pathway_name.trim() },
       );
       setVisible(false);

--- a/src/features/project/components/modals/DuplicateScenarioModal.jsx
+++ b/src/features/project/components/modals/DuplicateScenarioModal.jsx
@@ -23,7 +23,7 @@ const DuplicateScenarioModal = ({
     setLoading(true);
     try {
       await apiClient.post(
-        `/api/project/scenario/${currentScenarioName}/duplicate`,
+        `/project/scenario/${currentScenarioName}/duplicate`,
         {
           name: values.scenario_name,
         },

--- a/src/features/project/components/modals/NewProjectModal.jsx
+++ b/src/features/project/components/modals/NewProjectModal.jsx
@@ -58,7 +58,7 @@ const NewProjectModal = ({
         example_project: exampleProject,
         ...values,
       });
-      const resp = await apiClient.post(`/api/project/`, {
+      const resp = await apiClient.post(`/project/`, {
         example_project: exampleProject,
         ...values,
       });

--- a/src/features/project/hooks/index.jsx
+++ b/src/features/project/hooks/index.jsx
@@ -11,7 +11,7 @@ import { scenarioHeaders } from 'lib/api/scenarioContext';
 const updateConfigProjectInfo = async (project, scenarioName) => {
   try {
     const resp = await apiClient.put(
-      `/api/project/`,
+      `/project/`,
       { scenario_name: scenarioName },
       { headers: scenarioHeaders({ project }) },
     );

--- a/src/features/project/stores/projectStore.jsx
+++ b/src/features/project/stores/projectStore.jsx
@@ -19,14 +19,14 @@ const DEFAULT_PROJECT_PROPS = {
 const DEMO_PROJECT_TOKEN = '__demo__';
 
 export const fetchConfig = async () => {
-  const response = await apiClient.get(`/api/project/config`);
+  const response = await apiClient.get(`/project/config`);
   return response.data;
 };
 
 export const fetchProjectInfo = async (project) => {
   if (!project) throw new Error('Project cannot be empty');
   try {
-    const { data } = await apiClient.get(`/api/project/`, {
+    const { data } = await apiClient.get(`/project/`, {
       headers: scenarioHeaders({ project }),
     });
 
@@ -42,7 +42,7 @@ export const deleteScenario = async (project, scenario) => {
   if (!scenario) throw new Error('Scenario cannot be empty');
 
   try {
-    const { data } = await apiClient.delete(`/api/project/scenario`, {
+    const { data } = await apiClient.delete(`/project/scenario`, {
       headers: scenarioHeaders({ project }),
       data: { scenario_name: scenario },
     });
@@ -56,7 +56,7 @@ export const deleteScenario = async (project, scenario) => {
 
 export const fetchProjectChoices = async () => {
   try {
-    const { data } = await apiClient.get(`/api/project/choices`);
+    const { data } = await apiClient.get(`/project/choices`);
 
     return data;
   } catch (error) {
@@ -126,7 +126,7 @@ export const useProjectStore = create((set) => ({
 
   // Demo mode (anonymous, no valid session): seed project/scenario state
   // directly from the public demo scenario allowlist (`GET
-  // /api/demo/scenarios`) instead of fetching from `/api/project/*`, which
+  // /demo/scenarios`) instead of fetching from `/project/*`, which
   // requires a session. See stores/demoStore.js and app/UserCheckGate.jsx.
   seedDemoProject: ({ scenario, scenariosList }) =>
     set({

--- a/src/features/scenario/components/CreateScenarioForms/ContextForm.jsx
+++ b/src/features/scenario/components/CreateScenarioForms/ContextForm.jsx
@@ -35,7 +35,7 @@ const validateDatabase = async (value, databases) => {
   if (databases.includes(value)) return Promise.resolve();
 
   try {
-    const response = await apiClient.post(`/api/databases/validate`, {
+    const response = await apiClient.post(`/databases/validate`, {
       type: 'path',
       path: value,
     });

--- a/src/features/scenario/components/CreateScenarioForms/GeometryForm.jsx
+++ b/src/features/scenario/components/CreateScenarioForms/GeometryForm.jsx
@@ -23,7 +23,7 @@ const validateGeometry = async (value, buildingType) => {
   else if (value === undefined) return Promise.reject();
 
   try {
-    const response = await apiClient.post(`/api/geometry/buildings/validate`, {
+    const response = await apiClient.post(`/geometry/buildings/validate`, {
       type: 'path',
       building: buildingType,
       path: value,
@@ -41,7 +41,7 @@ const validateTypology = async (value) => {
   if (value === undefined) return Promise.reject();
 
   try {
-    const response = await apiClient.post(`/api/geometry/typology/validate`, {
+    const response = await apiClient.post(`/geometry/typology/validate`, {
       type: 'path',
       path: value,
     });

--- a/src/features/scenario/hooks/create-scenario-forms.js
+++ b/src/features/scenario/hooks/create-scenario-forms.js
@@ -8,7 +8,7 @@ export const useFetchDatabases = () => {
   const [databases, setDatabases] = useState([]);
 
   const fetchDatabases = async () => {
-    const { data } = await apiClient.get(`/api/databases/region`);
+    const { data } = await apiClient.get(`/databases/region`);
     return data;
   };
 
@@ -25,7 +25,7 @@ export const useFetchWeather = () => {
   const [weather, setWeather] = useState([]);
 
   const fetchWeather = async () => {
-    const { data } = await apiClient.get(`/api/weather`);
+    const { data } = await apiClient.get(`/weather`);
     return data;
   };
 
@@ -59,7 +59,7 @@ export const useCreateScenario = (projectPath, { onSuccess }) => {
         }
       });
       const response = await apiClient.postForm(
-        `/api/project/scenario`,
+        `/project/scenario`,
         formattedData,
         { headers: scenarioHeaders({ project: projectPath }) },
       );

--- a/src/features/tools/components/Tools/ToolFormButtons.jsx
+++ b/src/features/tools/components/Tools/ToolFormButtons.jsx
@@ -141,7 +141,7 @@ export const ToolFormButtons = ({
       if (value) {
         try {
           const resp = await getScenarioClient().post(
-            `/api/tools/${script}/validate-field`,
+            `/tools/${script}/validate-field`,
             {
               parameter_name: fieldName,
               value,

--- a/src/features/tools/hooks/mutations/useCheckInputsMutation.js
+++ b/src/features/tools/hooks/mutations/useCheckInputsMutation.js
@@ -16,7 +16,7 @@ export function useCheckInputsMutation(scenarioContext) {
 
       try {
         const response = await getScenarioClient().post(
-          `/api/tools/${tool}/check`,
+          `/tools/${tool}/check`,
           parameters,
           { headers: scenarioHeaders(scenarioContext) },
         );

--- a/src/features/tools/hooks/mutations/useSaveToolParams.js
+++ b/src/features/tools/hooks/mutations/useSaveToolParams.js
@@ -18,7 +18,7 @@ export function useSaveToolParamsMutation() {
     mutationFn: async ({ tool, params }) => {
       try {
         const response = await apiClient.post(
-          `/api/tools/${tool}/save-config`,
+          `/tools/${tool}/save-config`,
           params,
           { headers: activeScenarioHeaders() },
         );

--- a/src/features/tools/hooks/mutations/useSetDefaultToolParams.js
+++ b/src/features/tools/hooks/mutations/useSetDefaultToolParams.js
@@ -21,7 +21,7 @@ export function useSetDefaultToolParamsMutation() {
     mutationFn: async (tool) => {
       try {
         const response = await apiClient.post(
-          `/api/tools/${tool}/default`,
+          `/tools/${tool}/default`,
           undefined,
           { headers: activeScenarioHeaders() },
         );

--- a/src/features/tools/hooks/useParameterMetadataRefetch.js
+++ b/src/features/tools/hooks/useParameterMetadataRefetch.js
@@ -12,7 +12,7 @@ const useParameterMetadataRefetch = (script, form) => {
       let response;
       try {
         response = await getScenarioClient().post(
-          `/api/tools/${script}/parameter-metadata`,
+          `/tools/${script}/parameter-metadata`,
           {
             form_values: formValues,
             affected_parameters: affectedParams,

--- a/src/features/tools/hooks/useToolList.js
+++ b/src/features/tools/hooks/useToolList.js
@@ -4,7 +4,7 @@ import { getScenarioClient } from 'lib/api/axios';
 export const TOOL_LIST_QUERY_KEY = ['toolList'];
 
 const fetchToolList = async () => {
-  const response = await getScenarioClient().get('/api/tools');
+  const response = await getScenarioClient().get('/tools');
   return response.data;
 };
 

--- a/src/features/tools/hooks/useToolParams.js
+++ b/src/features/tools/hooks/useToolParams.js
@@ -47,12 +47,12 @@ const useFetchToolParams = (script, scenarioContext) => {
     ],
     queryFn: async () => {
       if (!script) return null;
-      // In demo mode, GET /api/tools/{script} deliberately returns empty
+      // In demo mode, GET /tools/{script} deliberately returns empty
       // `parameters`/`categorical_parameters` (backend never resolves real
       // values for anonymous callers) - the form renders with no fields
       // rather than real read-only values. Write routes (save-config,
       // validate-field, check) stay excluded entirely.
-      const response = await getScenarioClient().get(`/api/tools/${script}`, {
+      const response = await getScenarioClient().get(`/tools/${script}`, {
         headers: scenarioHeaders({ project, scenarioName, childScenario }),
       });
       return response.data;

--- a/src/features/tools/toolConfigStorage.js
+++ b/src/features/tools/toolConfigStorage.js
@@ -64,7 +64,7 @@ export const clearStoredToolConfig = (userID, paramNames) => {
   if (changed) writeStoredToolConfig(userID, next);
 };
 
-// Returns every parameter name known to a `/api/tools/{script}` response
+// Returns every parameter name known to a `/tools/{script}` response
 // (both flat `parameters` and grouped `categorical_parameters`).
 export const getToolParamNames = (data) => {
   if (!data) return [];
@@ -73,7 +73,7 @@ export const getToolParamNames = (data) => {
   return [...names, ...categorical.map((p) => p.name)];
 };
 
-// Pure: returns a shallow copy of a `/api/tools/{script}` response with each
+// Pure: returns a shallow copy of a `/tools/{script}` response with each
 // parameter's `.value` replaced by the stored value, when present.
 export const overlayStoredValues = (data, storedMap) => {
   if (!data || !storedMap || Object.keys(storedMap).length === 0) return data;

--- a/src/features/upload-download/components/UploadForm.jsx
+++ b/src/features/upload-download/components/UploadForm.jsx
@@ -557,7 +557,7 @@ const FormContent = ({ onSuccess }) => {
 
     xhr.open(
       'POST',
-      `${import.meta.env.VITE_CEA_URL}/api/contents/scenario/upload`,
+      `${import.meta.env.VITE_CEA_URL}/contents/scenario/upload`,
       true,
     );
     xhr.setRequestHeader(PROJECT_HEADER, values.project.project);

--- a/src/features/upload-download/stores/downloadStore.js
+++ b/src/features/upload-download/stores/downloadStore.js
@@ -56,7 +56,7 @@ const useDownloadStore = create((set, get) => ({
   prepareDownload: async (project, scenarios, inputFiles, outputFiles) => {
     try {
       const response = await apiClient.post(
-        '/api/downloads/prepare',
+        '/downloads/prepare',
         {
           scenarios,
           input_files: inputFiles,
@@ -77,7 +77,7 @@ const useDownloadStore = create((set, get) => ({
   // Fetch all downloads for current project/user
   fetchDownloads: async () => {
     try {
-      const response = await apiClient.get('/api/downloads/', {
+      const response = await apiClient.get('/downloads/', {
         headers: activeScenarioHeaders(),
       });
       const downloads = response.data;
@@ -101,7 +101,7 @@ const useDownloadStore = create((set, get) => ({
     try {
       // First check download status to ensure it's ready and handle errors
       const statusResponse = await apiClient.get(
-        `/api/downloads/${downloadId}/status`,
+        `/downloads/${downloadId}/status`,
       );
       const downloadStatus = statusResponse.data;
 
@@ -120,7 +120,7 @@ const useDownloadStore = create((set, get) => ({
 
       // Get pre-signed download URL (expires in 5 minutes by default)
       const urlResponse = await apiClient.get(
-        `/api/downloads/${downloadId}/url`,
+        `/downloads/${downloadId}/url`,
       );
       const { url } = urlResponse.data;
 
@@ -153,7 +153,7 @@ const useDownloadStore = create((set, get) => ({
       } else if (error.response) {
         try {
           const statusResponse = await apiClient.get(
-            `/api/downloads/${downloadId}/status`,
+            `/downloads/${downloadId}/status`,
           );
           get().upsertDownload(statusResponse.data);
         } catch {
@@ -170,7 +170,7 @@ const useDownloadStore = create((set, get) => ({
   // Delete a download
   deleteDownload: async (downloadId) => {
     try {
-      await apiClient.delete(`/api/downloads/${downloadId}`);
+      await apiClient.delete(`/downloads/${downloadId}`);
       get().removeDownload(downloadId);
       return true;
     } catch (error) {

--- a/src/features/upload-download/stores/downloadStore.js
+++ b/src/features/upload-download/stores/downloadStore.js
@@ -119,9 +119,7 @@ const useDownloadStore = create((set, get) => ({
       }
 
       // Get pre-signed download URL (expires in 5 minutes by default)
-      const urlResponse = await apiClient.get(
-        `/downloads/${downloadId}/url`,
-      );
+      const urlResponse = await apiClient.get(`/downloads/${downloadId}/url`);
       const { url } = urlResponse.data;
 
       // Trigger download using pre-signed URL

--- a/src/lib/api/axios.js
+++ b/src/lib/api/axios.js
@@ -81,8 +81,8 @@ export const publicClient = axios.create({
 
 // For anonymous, read-only demo scenario viewing (no valid session - see
 // UserCheckGate). Requests made with this client are rewritten below to hit
-// the public `/api/demo/scenarios/{demoId}/...` sub-app instead of the normal
-// `/api/...` routes, so existing hooks/queries can be pointed at demo data by
+// the public `/demo/scenarios/{demoId}/...` sub-app instead of the normal
+// flat-root routes, so existing hooks/queries can be pointed at demo data by
 // swapping their client, not their URLs.
 //
 // One active `demoId` per session, not per request: X-CEA-* headers are
@@ -96,10 +96,14 @@ export const demoClient = axios.create({
 });
 
 demoClient.interceptors.request.use((config) => {
-  const { demoId } = useDemoStore.getState();
+  const { demoId, routePrefixes } = useDemoStore.getState();
 
-  if (demoId && config.url?.startsWith('/api/')) {
-    config.url = `/api/demo/scenarios/${encodeURIComponent(demoId)}${config.url.slice('/api'.length)}`;
+  // routePrefixes is backend-derived (see UserCheckGate's bootstrap fetch),
+  // not a hardcoded list - it's the only signal left for "this is a
+  // scenario-scoped route eligible for demo redirection" now that api-router
+  // paths, /server/*, and /plots/* all share one flat root namespace.
+  if (demoId && routePrefixes.some((p) => config.url?.startsWith(p))) {
+    config.url = `/demo/scenarios/${encodeURIComponent(demoId)}${config.url}`;
   }
 
   // The demo sub-app resolves scenario context from the URL path
@@ -116,7 +120,7 @@ demoClient.interceptors.request.use((config) => {
 
 // Returns the axios client that should be used for scenario-scoped reads
 // (inputs, map layers, canvas). Callers that already build their requests
-// against `apiClient`'s normal `/api/...` URLs can swap in this client to
+// against `apiClient`'s normal `/...` URLs can swap in this client to
 // transparently support demo mode - no other changes needed.
 export const getScenarioClient = () =>
   useDemoStore.getState().demoMode ? demoClient : apiClient;
@@ -194,11 +198,11 @@ const addAuthInterceptor = (client, refreshUrl) => {
 // Apply interceptors to both clients
 addAuthInterceptor(
   apiClient,
-  `${import.meta.env.VITE_CEA_URL}/api/user/session/refresh`,
+  `${import.meta.env.VITE_CEA_URL}/user/session/refresh`,
 );
 addAuthInterceptor(
   authClient,
-  `${import.meta.env.VITE_CEA_URL}/api/user/session/refresh`,
+  `${import.meta.env.VITE_CEA_URL}/user/session/refresh`,
 );
 
 // JSON requests can't carry a browser File — JSON.stringify(File) yields

--- a/src/lib/api/axios.test.js
+++ b/src/lib/api/axios.test.js
@@ -1,0 +1,137 @@
+import axios from 'axios';
+
+import useDemoStore from 'stores/demoStore';
+import {
+  PROJECT_HEADER,
+  SCENARIO_NAME_HEADER,
+  CHILD_SCENARIO_HEADER,
+} from 'lib/api/scenarioContextHeaders';
+
+import { apiClient, demoClient } from './axios';
+
+// Interceptors are registered once at module load and there's no public API
+// to invoke them in isolation, so tests reach into the axios interceptor
+// manager directly - this is the standard way to unit-test an axios
+// interceptor without a real network layer or an extra mocking dependency.
+const demoInterceptor = demoClient.interceptors.request.handlers[0].fulfilled;
+// Registration order in axios.js: addAuthInterceptor() runs before the
+// stripFiles interceptor is registered, so index 0 is always the auth one.
+const apiAuthInterceptor = apiClient.interceptors.request.handlers[0].fulfilled;
+
+const initialDemoState = useDemoStore.getInitialState();
+
+const clearCookies = () => {
+  document.cookie.split(';').forEach((c) => {
+    const name = c.split('=')[0].trim();
+    if (name) {
+      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/`;
+    }
+  });
+};
+
+beforeEach(() => {
+  useDemoStore.setState(initialDemoState, true);
+  clearCookies();
+});
+
+afterEach(() => {
+  clearCookies();
+  vi.restoreAllMocks();
+});
+
+describe('demoClient interceptor', () => {
+  it('rewrites a demo-eligible URL to /demo/scenarios/{demoId}/... when demoId and a matching prefix are set', () => {
+    useDemoStore.setState({
+      demoId: 'baseline',
+      routePrefixes: ['/inputs/', '/canvas/'],
+    });
+
+    const config = demoInterceptor({ url: '/inputs/all-inputs', headers: {} });
+
+    expect(config.url).toBe('/demo/scenarios/baseline/inputs/all-inputs');
+  });
+
+  it('URL-encodes the demoId when rewriting', () => {
+    useDemoStore.setState({ demoId: 'a demo/id', routePrefixes: ['/inputs/'] });
+
+    const config = demoInterceptor({ url: '/inputs/all-inputs', headers: {} });
+
+    expect(config.url).toBe('/demo/scenarios/a%20demo%2Fid/inputs/all-inputs');
+  });
+
+  it('leaves a non-matching URL untouched, even with an active demoId', () => {
+    // Regression case: the old interceptor keyed off a bare '/api/' prefix,
+    // which wrongly rewrote every api-router route including /project/*.
+    // routePrefixes is the backend-derived allowlist that replaced it.
+    useDemoStore.setState({
+      demoId: 'baseline',
+      routePrefixes: ['/inputs/', '/canvas/'],
+    });
+
+    const config = demoInterceptor({ url: '/project/', headers: {} });
+
+    expect(config.url).toBe('/project/');
+  });
+
+  it('does not rewrite when routePrefixes is empty (bootstrap has not returned yet)', () => {
+    useDemoStore.setState({ demoId: 'baseline', routePrefixes: [] });
+
+    const config = demoInterceptor({ url: '/inputs/all-inputs', headers: {} });
+
+    expect(config.url).toBe('/inputs/all-inputs');
+  });
+
+  it('does not rewrite when there is no active demoId', () => {
+    useDemoStore.setState({ demoId: null, routePrefixes: ['/inputs/'] });
+
+    const config = demoInterceptor({ url: '/inputs/all-inputs', headers: {} });
+
+    expect(config.url).toBe('/inputs/all-inputs');
+  });
+
+  it('strips every X-CEA-* scenario header, matched request or not', () => {
+    useDemoStore.setState({ demoId: null, routePrefixes: [] });
+
+    const config = demoInterceptor({
+      url: '/project/',
+      headers: {
+        [PROJECT_HEADER]: 'some-project',
+        [SCENARIO_NAME_HEADER]: 'baseline',
+        [CHILD_SCENARIO_HEADER]: 'pathway/2030',
+        'Content-Type': 'application/json',
+      },
+    });
+
+    expect(config.headers).not.toHaveProperty(PROJECT_HEADER);
+    expect(config.headers).not.toHaveProperty(SCENARIO_NAME_HEADER);
+    expect(config.headers).not.toHaveProperty(CHILD_SCENARIO_HEADER);
+    expect(config.headers['Content-Type']).toBe('application/json');
+  });
+});
+
+describe('session refresh URL', () => {
+  // Regression check for the exact string this migration changed: the
+  // refresh call bypasses both clients' baseURL config (bare axios.post), so
+  // it's the one place a stray '/api' prefix could silently come back.
+  const buildAccessToken = (exp) =>
+    `header.${btoa(JSON.stringify({ exp }))}.signature`;
+
+  it('apiClient refreshes against {VITE_CEA_URL}/user/session/refresh, no /api prefix', async () => {
+    const expiredToken = buildAccessToken(Math.floor(Date.now() / 1000)); // already expired
+    document.cookie = `stack-access=${encodeURIComponent(
+      JSON.stringify(['refresh-token', expiredToken]),
+    )}`;
+
+    const postSpy = vi
+      .spyOn(axios, 'post')
+      .mockResolvedValue({ data: { access_token: 'new-token' } });
+
+    await apiAuthInterceptor({ headers: {} });
+
+    expect(postSpy).toHaveBeenCalledWith(
+      'http://backend.test/user/session/refresh',
+      {},
+      { withCredentials: true },
+    );
+  });
+});

--- a/src/lib/api/endpoints.js
+++ b/src/lib/api/endpoints.js
@@ -1,3 +1,3 @@
 export const API_ENDPOINTS = {
-  INPUTS: '/api/inputs',
+  INPUTS: '/inputs',
 };

--- a/src/stores/demoStore.js
+++ b/src/stores/demoStore.js
@@ -8,19 +8,26 @@ const useDemoStore = create((set) => ({
   demoMode: false,
   demoId: null,
   demoScenarios: [], // [{ id, name }, ...]
+  // Domains the demo sub-app serves (e.g. '/inputs/', '/canvas/'), returned
+  // by the backend alongside the scenario list. Read by lib/api/axios.js's
+  // demoClient interceptor to decide which requests are demo-eligible -
+  // backend-derived so it can't drift from the actual demo route table.
+  routePrefixes: [],
 
   // Enter demo mode with the fetched scenario list, defaulting to the
   // first scenario (if any) as the active one.
-  enterDemo: (scenarios) =>
+  enterDemo: (scenarios, routePrefixes = []) =>
     set({
       demoMode: true,
       demoScenarios: scenarios,
       demoId: scenarios?.[0]?.id ?? null,
+      routePrefixes,
     }),
 
   setDemoId: (demoId) => set({ demoId }),
 
-  exitDemo: () => set({ demoMode: false, demoId: null, demoScenarios: [] }),
+  exitDemo: () =>
+    set({ demoMode: false, demoId: null, demoScenarios: [], routePrefixes: [] }),
 }));
 
 export const useDemoMode = () => useDemoStore((state) => state.demoMode);

--- a/src/stores/demoStore.js
+++ b/src/stores/demoStore.js
@@ -27,7 +27,12 @@ const useDemoStore = create((set) => ({
   setDemoId: (demoId) => set({ demoId }),
 
   exitDemo: () =>
-    set({ demoMode: false, demoId: null, demoScenarios: [], routePrefixes: [] }),
+    set({
+      demoMode: false,
+      demoId: null,
+      demoScenarios: [],
+      routePrefixes: [],
+    }),
 }));
 
 export const useDemoMode = () => useDemoStore((state) => state.demoMode);

--- a/src/stores/demoStore.test.js
+++ b/src/stores/demoStore.test.js
@@ -1,0 +1,75 @@
+import useDemoStore from './demoStore';
+
+// demoStore has no imports outside zustand, so tests interact with the
+// store directly rather than mocking anything.
+
+const initialState = useDemoStore.getInitialState();
+
+beforeEach(() => {
+  useDemoStore.setState(initialState, true);
+});
+
+describe('enterDemo', () => {
+  it('enters demo mode, defaults demoId to the first scenario, and stores routePrefixes', () => {
+    const scenarios = [
+      { id: 'baseline', name: 'baseline' },
+      { id: 'alt', name: 'alt' },
+    ];
+    const routePrefixes = ['/inputs/', '/canvas/'];
+
+    useDemoStore.getState().enterDemo(scenarios, routePrefixes);
+
+    const state = useDemoStore.getState();
+    expect(state.demoMode).toBe(true);
+    expect(state.demoScenarios).toBe(scenarios);
+    expect(state.demoId).toBe('baseline');
+    expect(state.routePrefixes).toBe(routePrefixes);
+  });
+
+  it('leaves demoId null when the scenario list is empty (the UserCheckGate error-fallback path)', () => {
+    useDemoStore.getState().enterDemo([]);
+
+    const state = useDemoStore.getState();
+    expect(state.demoMode).toBe(true);
+    expect(state.demoId).toBeNull();
+    expect(state.demoScenarios).toEqual([]);
+  });
+
+  it('defaults routePrefixes to [] when the caller omits it', () => {
+    useDemoStore.getState().enterDemo([{ id: 'baseline' }]);
+
+    expect(useDemoStore.getState().routePrefixes).toEqual([]);
+  });
+});
+
+describe('setDemoId', () => {
+  it('updates demoId without touching other fields', () => {
+    useDemoStore
+      .getState()
+      .enterDemo([{ id: 'baseline' }, { id: 'alt' }], ['/inputs/']);
+
+    useDemoStore.getState().setDemoId('alt');
+
+    const state = useDemoStore.getState();
+    expect(state.demoId).toBe('alt');
+    expect(state.demoMode).toBe(true);
+    expect(state.routePrefixes).toEqual(['/inputs/']);
+  });
+});
+
+describe('exitDemo', () => {
+  it('clears every field, including routePrefixes, back to its initial value', () => {
+    useDemoStore
+      .getState()
+      .enterDemo([{ id: 'baseline' }], ['/inputs/', '/canvas/']);
+
+    useDemoStore.getState().exitDemo();
+
+    expect(useDemoStore.getState()).toMatchObject({
+      demoMode: false,
+      demoId: null,
+      demoScenarios: [],
+      routePrefixes: [],
+    });
+  });
+});

--- a/src/stores/useUserQuery.js
+++ b/src/stores/useUserQuery.js
@@ -6,7 +6,7 @@ export const USER_QUERY_KEY = ['user'];
 
 const fetchUser = async () => {
   try {
-    const resp = await apiClient.get('/api/user');
+    const resp = await apiClient.get('/user');
     return resp.data;
   } catch (err) {
     if (err.response?.status === 401) return null; // no session or unauthorized

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,0 +1,26 @@
+import '@testing-library/jest-dom/vitest';
+
+// jsdom doesn't implement matchMedia (antd v6 uses it for responsive
+// components) or ResizeObserver. Stub only what this first-wave suite
+// actually touches - add more here if a later test needs them, don't
+// pre-stub for code paths nothing exercises yet.
+if (!window.matchMedia) {
+  window.matchMedia = (query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  });
+}
+
+if (!window.ResizeObserver) {
+  window.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}

--- a/src/utils/file.js
+++ b/src/utils/file.js
@@ -20,7 +20,7 @@ export const getContentInfo = async (
   content_type = 'directory',
 ) => {
   try {
-    const { data } = await apiClient.get('/api/contents', {
+    const { data } = await apiClient.get('/contents', {
       params: { content_type, content_path },
     });
     return data;

--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -60,7 +60,7 @@ export const validateNetworkNameCollision = async (
       'network-type': config.network_type,
     };
 
-    await apiClient.post(`/api/tools/${tool}/save-config`, params);
+    await apiClient.post(`/tools/${tool}/save-config`, params);
     return Promise.resolve();
   } catch (error) {
     // Backend validation failed - extract error message

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -29,6 +29,21 @@ export default defineConfig(({ mode }) => {
       // Optimize chunk size
       chunkSizeWarningLimit: 1000,
     },
+    test: {
+      environment: 'jsdom',
+      globals: true,
+      setupFiles: ['./src/test/setup.js'],
+      css: false,
+      // .env defines VITE_CEA_URL="" and leaves VITE_AUTH_URL /
+      // VITE_AUTH_COOKIE_NAME unset - template-literal interpolation turns an
+      // unset var into the literal string "undefined", so pin real-looking
+      // values here for meaningful URL assertions in tests.
+      env: {
+        VITE_CEA_URL: 'http://backend.test',
+        VITE_AUTH_URL: 'http://auth.test',
+        VITE_AUTH_COOKIE_NAME: 'stack-access',
+      },
+    },
   };
 
   if (mode === 'electron') {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12,6 +12,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@adobe/css-tools@npm:^4.4.0":
+  version: 4.5.0
+  resolution: "@adobe/css-tools@npm:4.5.0"
+  checksum: 10c0/fc969e1117098eb4cccdb73beb2508daa0e52760af1183d6288bafea59204943490ab3ede28593032ffb8929c0cee270b2a53254fe61139ab00604ea8fc33cea
+  languageName: node
+  linkType: hard
+
 "@ant-design/colors@npm:^8.0.0":
   version: 8.0.0
   resolution: "@ant-design/colors@npm:8.0.0"
@@ -97,6 +104,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@asamuzakjp/css-color@npm:^6.0.5":
+  version: 6.0.5
+  resolution: "@asamuzakjp/css-color@npm:6.0.5"
+  dependencies:
+    "@csstools/css-calc": "npm:^3.2.1"
+    "@csstools/css-color-parser": "npm:^4.1.9"
+    "@csstools/css-parser-algorithms": "npm:^4.0.0"
+    "@csstools/css-tokenizer": "npm:^4.0.0"
+    lru-cache: "npm:^11.5.2"
+  checksum: 10c0/c08cc6bcea92c5e04fac208fbdbd125ed89e0eeca258df48819878347c75f90c3eb3a52940049fcb580ac9afe83c1d6bbf4e4caee0f8c2655cf47286f6ce3f09
+  languageName: node
+  linkType: hard
+
+"@asamuzakjp/dom-selector@npm:^8.3.0":
+  version: 8.3.2
+  resolution: "@asamuzakjp/dom-selector@npm:8.3.2"
+  dependencies:
+    bidi-js: "npm:^1.0.3"
+    css-tree: "npm:^3.2.1"
+    is-potential-custom-element-name: "npm:^1.0.1"
+    lru-cache: "npm:^11.5.2"
+  checksum: 10c0/f39e2cee4e6ef034af405e0fe272c8e3d27dcf8cc123fd6a5801a9dea3f8bbdfeee05a1a58e08f364ca8f7608a2749bd6e21c61265e15c2a0e6dd913e2f63bba
+  languageName: node
+  linkType: hard
+
 "@babel/code-frame@npm:^7.0.0, @babel/code-frame@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/code-frame@npm:7.27.1"
@@ -105,6 +137,17 @@ __metadata:
     js-tokens: "npm:^4.0.0"
     picocolors: "npm:^1.1.1"
   checksum: 10c0/5dd9a18baa5fce4741ba729acc3a3272c49c25cb8736c4b18e113099520e7ef7b545a4096a26d600e4416157e63e87d66db46aa3fbf0a5f2286da2705c12da00
+  languageName: node
+  linkType: hard
+
+"@babel/code-frame@npm:^7.10.4":
+  version: 7.29.7
+  resolution: "@babel/code-frame@npm:7.29.7"
+  dependencies:
+    "@babel/helper-validator-identifier": "npm:^7.29.7"
+    js-tokens: "npm:^4.0.0"
+    picocolors: "npm:^1.1.1"
+  checksum: 10c0/169fc2080169a40c1760155eaaaf739bcb882df0bec76a83adbda5493645bc17270a3434b8848c494b1933e96fe1d147370001e3cda09a39f43ae30f08ef2069
   languageName: node
   linkType: hard
 
@@ -283,6 +326,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-validator-identifier@npm:^7.29.7":
+  version: 7.29.7
+  resolution: "@babel/helper-validator-identifier@npm:7.29.7"
+  checksum: 10c0/4795354e7ae0dcafa72de1cd04ec51252dc1498517170beaf019e03effc5b7bf13c6b21a3949a77e07b8125be7f106ed1131350d8ebd4566ae874094a726d62b
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-option@npm:^7.27.1":
   version: 7.27.1
   resolution: "@babel/helper-validator-option@npm:7.27.1"
@@ -340,6 +390,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.12.5":
+  version: 7.29.7
+  resolution: "@babel/runtime@npm:7.29.7"
+  checksum: 10c0/ca11572f7146b21e0bde6a9ed4bb6a89eafbee5f0944c7eb54d0d8a2dac962c33638a1d611e14faa71dfbb92b4b5f9236232208568a6b7d5c6f3f39ddb91771e
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.27.2":
   version: 7.27.2
   resolution: "@babel/template@npm:7.27.2"
@@ -376,6 +433,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@bramus/specificity@npm:^2.4.2":
+  version: 2.4.2
+  resolution: "@bramus/specificity@npm:2.4.2"
+  dependencies:
+    css-tree: "npm:^3.0.0"
+  bin:
+    specificity: bin/cli.js
+  checksum: 10c0/c5f4e04e0bca0d2202598207a5eb0733c8109d12a68a329caa26373bec598d99db5bb785b8865fefa00fc01b08c6068138807ceb11a948fe15e904ed6cf4ba72
+  languageName: node
+  linkType: hard
+
 "@carto/api-client@npm:^0.5.19":
   version: 0.5.22
   resolution: "@carto/api-client@npm:0.5.22"
@@ -388,6 +456,64 @@ __metadata:
     jsep: "npm:^1.4.0"
     quadbin: "npm:^0.4.1-alpha.0"
   checksum: 10c0/942dd42d6f651dfb26b0ae73571d614da77d85a739f335f13cd10a48061224c6afaf3cd44eb5dc8f08e9530d51819c26162ee069f981de1606fd3c9906e537eb
+  languageName: node
+  linkType: hard
+
+"@csstools/color-helpers@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "@csstools/color-helpers@npm:6.1.0"
+  checksum: 10c0/ebb71eebcd6dde16a89d687c30d4c7f315f9079ec803497ebac0528d0a9ef09847eaf167b4565c4919f156e32e7ca2167199ac2d2020f184f7888551a3b4712b
+  languageName: node
+  linkType: hard
+
+"@csstools/css-calc@npm:^3.2.1, @csstools/css-calc@npm:^3.3.0":
+  version: 3.3.0
+  resolution: "@csstools/css-calc@npm:3.3.0"
+  peerDependencies:
+    "@csstools/css-parser-algorithms": ^4.0.0
+    "@csstools/css-tokenizer": ^4.0.0
+  checksum: 10c0/83157b9fbf3599dfff2338ac40e7eec0884d1d729b9ca4a949af3c2da55d14368b2ac70ff4f659fc1ec6801a48c9225f2211a8be987678aadf6795dbebe5a2da
+  languageName: node
+  linkType: hard
+
+"@csstools/css-color-parser@npm:^4.1.9":
+  version: 4.1.10
+  resolution: "@csstools/css-color-parser@npm:4.1.10"
+  dependencies:
+    "@csstools/color-helpers": "npm:^6.1.0"
+    "@csstools/css-calc": "npm:^3.3.0"
+  peerDependencies:
+    "@csstools/css-parser-algorithms": ^4.0.0
+    "@csstools/css-tokenizer": ^4.0.0
+  checksum: 10c0/d8fe23036f8d9cdbb9fc99f09e2803a74c280c511ccf25c4990f4913c0e23c7687138a85c8c27eeec509c2e3aa72957b8c328ce295d3faaa16cb8fd4b4ede122
+  languageName: node
+  linkType: hard
+
+"@csstools/css-parser-algorithms@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@csstools/css-parser-algorithms@npm:4.0.0"
+  peerDependencies:
+    "@csstools/css-tokenizer": ^4.0.0
+  checksum: 10c0/94558c2428d6ef0ddef542e86e0a8376aa1263a12a59770abb13ba50d7b83086822c75433f32aa2e7fef00555e1cc88292f9ca5bce79aed232bb3fed73b1528d
+  languageName: node
+  linkType: hard
+
+"@csstools/css-syntax-patches-for-csstree@npm:^1.1.7":
+  version: 1.1.7
+  resolution: "@csstools/css-syntax-patches-for-csstree@npm:1.1.7"
+  peerDependencies:
+    css-tree: ^3.2.1
+  peerDependenciesMeta:
+    css-tree:
+      optional: true
+  checksum: 10c0/cdebc36196f951f4436132f5346927c8aeff2917a1c2af42ad36eb87a2b1883c8cd21cb6b3105e951ae0fa964d2ebda6309bae476d232d27f0ec657199df6bb6
+  languageName: node
+  linkType: hard
+
+"@csstools/css-tokenizer@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@csstools/css-tokenizer@npm:4.0.0"
+  checksum: 10c0/669cf3d0f9c8e1ffdf8c9955ad8beba0c8cfe03197fe29a4fcbd9ee6f7a18856cfa42c62670021a75183d9ab37f5d14a866e6a9df753a6c07f59e36797a9ea9f
   languageName: node
   linkType: hard
 
@@ -810,6 +936,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/core@npm:2.0.0-alpha.3":
+  version: 2.0.0-alpha.3
+  resolution: "@emnapi/core@npm:2.0.0-alpha.3"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:2.0.1"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/dfc26f53eb40dab0e316206cabe01e6e98d21ef8a0b820f81ce7e0fa7b4307c94f2a9599c11e6c601ad7bd77e8efb9b7cb9f86dbc3b6237f799405e0cb60c587
+  languageName: node
+  linkType: hard
+
 "@emnapi/runtime@npm:1.11.1":
   version: 1.11.1
   resolution: "@emnapi/runtime@npm:1.11.1"
@@ -819,12 +955,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@emnapi/runtime@npm:2.0.0-alpha.3":
+  version: 2.0.0-alpha.3
+  resolution: "@emnapi/runtime@npm:2.0.0-alpha.3"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/c8f6e0ad2f9c0ced8bc156a7ec3ab5fbbd2d3b7147b6a37537f6892131844b969d3aa450749807fc238160b5db61d6160b8066abfce4b2c40acfb1941bb31dd1
+  languageName: node
+  linkType: hard
+
 "@emnapi/wasi-threads@npm:1.2.2":
   version: 1.2.2
   resolution: "@emnapi/wasi-threads@npm:1.2.2"
   dependencies:
     tslib: "npm:^2.4.0"
   checksum: 10c0/f0dc8269d6b20ae5a7c7b36e7a6a333452009d461038ef4febb29da2f3f78c1e2b1576d7e8970a5c5789ed3caedc1f80f5b0c2a5373bdaf8d03b20432bb55747
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:2.0.1":
+  version: 2.0.1
+  resolution: "@emnapi/wasi-threads@npm:2.0.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/5f7bf4cc4f6a1c31ec2084c9321d054f3b3b6c7e89430bb23fc3487d55e7be40f1ff31b2cb9a51721b444d4e8ac1f065b8749606771f6e4e7ccb32bbb709a303
   languageName: node
   linkType: hard
 
@@ -927,6 +1081,18 @@ __metadata:
     "@eslint/core": "npm:^0.17.0"
     levn: "npm:^0.4.1"
   checksum: 10c0/51600f78b798f172a9915dffb295e2ffb44840d583427bc732baf12ecb963eb841b253300e657da91d890f4b323d10a1bd12934bf293e3018d8bb66fdce5217b
+  languageName: node
+  linkType: hard
+
+"@exodus/bytes@npm:^1.11.0, @exodus/bytes@npm:^1.15.1, @exodus/bytes@npm:^1.6.0":
+  version: 1.15.1
+  resolution: "@exodus/bytes@npm:1.15.1"
+  peerDependencies:
+    "@noble/hashes": ^1.8.0 || ^2.0.0
+  peerDependenciesMeta:
+    "@noble/hashes":
+      optional: true
+  checksum: 10c0/333056a6953bbf875d9f3b86c32314de29458d842e5f56f6ef8034b18c2d9660184550093d1bae5de0064043d5e23f54cc03148798d9d29cf5167ac03f2e9f8c
   languageName: node
   linkType: hard
 
@@ -1149,7 +1315,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.0":
+"@jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.0, @jridgewell/sourcemap-codec@npm:^1.5.5":
   version: 1.5.5
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
   checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
@@ -1847,6 +2013,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@napi-rs/wasm-runtime@npm:^1.2.0":
+  version: 1.2.2
+  resolution: "@napi-rs/wasm-runtime@npm:1.2.2"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.3"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1 || ^2.0.0-alpha.3
+    "@emnapi/runtime": ^1.7.1 || ^2.0.0-alpha.3
+  checksum: 10c0/670ff8359761660f58d95a29fe22ac959d2c295675144fe9bc35118b0e723d1e0ac192df9896ba428eb13930cf0893b632606b70ccaea259fd6eca1836c2eb09
+  languageName: node
+  linkType: hard
+
 "@nodable/entities@npm:^3.0.0":
   version: 3.0.0
   resolution: "@nodable/entities@npm:3.0.0"
@@ -1900,6 +2078,13 @@ __metadata:
   version: 0.139.0
   resolution: "@oxc-project/types@npm:0.139.0"
   checksum: 10c0/ad57d1bee4b972ecf6784183da12ac6865edfff326bd83712fb75262b901868bc2b72d6fb502465a5f0dbaaded2910003f73365caf3821901dad565cc0b7fdf2
+  languageName: node
+  linkType: hard
+
+"@oxc-project/types@npm:=0.142.0":
+  version: 0.142.0
+  resolution: "@oxc-project/types@npm:0.142.0"
+  checksum: 10c0/e4fa60b8fe1a77b0db6b9a2dcbc78d9a5a18ef64dffde01d909108f3ddbc562b876c568cb01e297ba71a256fc8aaafc928d4562475a9b2a25b276fee5bf635c3
   languageName: node
   linkType: hard
 
@@ -2626,9 +2811,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-android-arm64@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-android-arm64@npm:1.2.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-darwin-arm64@npm:1.1.5":
   version: 1.1.5
   resolution: "@rolldown/binding-darwin-arm64@npm:1.1.5"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-arm64@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.2.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -2640,9 +2839,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-darwin-x64@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-darwin-x64@npm:1.2.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-freebsd-x64@npm:1.1.5":
   version: 1.1.5
   resolution: "@rolldown/binding-freebsd-x64@npm:1.1.5"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-freebsd-x64@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.2.1"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -2654,9 +2867,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.2.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-arm64-gnu@npm:1.1.5":
   version: 1.1.5
   resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.1.5"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-gnu@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.2.1"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -2668,9 +2895,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-arm64-musl@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.2.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-ppc64-gnu@npm:1.1.5":
   version: 1.1.5
   resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.1.5"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-ppc64-gnu@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.2.1"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
@@ -2682,9 +2923,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-s390x-gnu@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.2.1"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-linux-x64-gnu@npm:1.1.5":
   version: 1.1.5
   resolution: "@rolldown/binding-linux-x64-gnu@npm:1.1.5"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-gnu@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.2.1"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -2696,9 +2951,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-linux-x64-musl@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.2.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-openharmony-arm64@npm:1.1.5":
   version: 1.1.5
   resolution: "@rolldown/binding-openharmony-arm64@npm:1.1.5"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-openharmony-arm64@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.2.1"
   conditions: os=openharmony & cpu=arm64
   languageName: node
   linkType: hard
@@ -2714,6 +2983,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-wasm32-wasi@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.2.1"
+  dependencies:
+    "@emnapi/core": "npm:2.0.0-alpha.3"
+    "@emnapi/runtime": "npm:2.0.0-alpha.3"
+    "@napi-rs/wasm-runtime": "npm:^1.2.0"
+  checksum: 10c0/e5bbfad1862187c60cd9cab802af22c71b2496f89fe73a161931f04594f9db1e09ad7a503a2f980f55a2f6d5a4d2013ad1d17260970ac170a1aa6b9286a41738
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-win32-arm64-msvc@npm:1.1.5":
   version: 1.1.5
   resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.1.5"
@@ -2721,9 +3001,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@rolldown/binding-win32-arm64-msvc@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.2.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "@rolldown/binding-win32-x64-msvc@npm:1.1.5":
   version: 1.1.5
   resolution: "@rolldown/binding-win32-x64-msvc@npm:1.1.5"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-x64-msvc@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.2.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -2772,7 +3066,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@standard-schema/spec@npm:^1.0.0":
+"@standard-schema/spec@npm:^1.0.0, @standard-schema/spec@npm:^1.1.0":
   version: 1.1.0
   resolution: "@standard-schema/spec@npm:1.1.0"
   checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
@@ -2954,6 +3248,67 @@ __metadata:
   peerDependencies:
     react: ^18 || ^19
   checksum: 10c0/da01ec2819d301e4be89731e82d3f091fa4f1ab2745be324e5166f9df77e2aaf1c362b0fa61aab226bb01634873f1a00562f7d7f405867fe23bdd47fe4d00fda
+  languageName: node
+  linkType: hard
+
+"@testing-library/dom@npm:^10.4.1":
+  version: 10.4.1
+  resolution: "@testing-library/dom@npm:10.4.1"
+  dependencies:
+    "@babel/code-frame": "npm:^7.10.4"
+    "@babel/runtime": "npm:^7.12.5"
+    "@types/aria-query": "npm:^5.0.1"
+    aria-query: "npm:5.3.0"
+    dom-accessibility-api: "npm:^0.5.9"
+    lz-string: "npm:^1.5.0"
+    picocolors: "npm:1.1.1"
+    pretty-format: "npm:^27.0.2"
+  checksum: 10c0/19ce048012d395ad0468b0dbcc4d0911f6f9e39464d7a8464a587b29707eed5482000dad728f5acc4ed314d2f4d54f34982999a114d2404f36d048278db815b1
+  languageName: node
+  linkType: hard
+
+"@testing-library/jest-dom@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "@testing-library/jest-dom@npm:7.0.0"
+  dependencies:
+    "@adobe/css-tools": "npm:^4.4.0"
+    aria-query: "npm:^5.0.0"
+    css.escape: "npm:^1.5.1"
+    dom-accessibility-api: "npm:^0.6.3"
+    picocolors: "npm:^1.1.1"
+    redent: "npm:^3.0.0"
+  peerDependencies:
+    "@testing-library/dom": ">=10 <11"
+  checksum: 10c0/f5ecf821ed098438a5e9ce993d431505f0a1af43edb05e423c6ab7becf9d7dbe46385fc93e0e460a4c7996f4513cad72b8967dd8e98c75bc7ea6733ff7efcf4e
+  languageName: node
+  linkType: hard
+
+"@testing-library/react@npm:^16.3.2":
+  version: 16.3.2
+  resolution: "@testing-library/react@npm:16.3.2"
+  dependencies:
+    "@babel/runtime": "npm:^7.12.5"
+  peerDependencies:
+    "@testing-library/dom": ^10.0.0
+    "@types/react": ^18.0.0 || ^19.0.0
+    "@types/react-dom": ^18.0.0 || ^19.0.0
+    react: ^18.0.0 || ^19.0.0
+    react-dom: ^18.0.0 || ^19.0.0
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10c0/f9c7f0915e1b5f7b750e6c7d8b51f091b8ae7ea99bacb761d7b8505ba25de9cfcb749a0f779f1650fb268b499dd79165dc7e1ee0b8b4cb63430d3ddc81ffe044
+  languageName: node
+  linkType: hard
+
+"@testing-library/user-event@npm:^14.6.1":
+  version: 14.6.1
+  resolution: "@testing-library/user-event@npm:14.6.1"
+  peerDependencies:
+    "@testing-library/dom": ">=7.21.4"
+  checksum: 10c0/75fea130a52bf320d35d46ed54f3eec77e71a56911b8b69a3fe29497b0b9947b2dc80d30f04054ad4ce7f577856ae3e5397ea7dff0ef14944d3909784c7a93fe
   languageName: node
   linkType: hard
 
@@ -5131,6 +5486,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/aria-query@npm:^5.0.1":
+  version: 5.0.4
+  resolution: "@types/aria-query@npm:5.0.4"
+  checksum: 10c0/dc667bc6a3acc7bba2bccf8c23d56cb1f2f4defaa704cfef595437107efaa972d3b3db9ec1d66bc2711bfc35086821edd32c302bffab36f2e79b97f312069f08
+  languageName: node
+  linkType: hard
+
 "@types/brotli@npm:^1.3.0":
   version: 1.3.4
   resolution: "@types/brotli@npm:1.3.4"
@@ -5149,6 +5511,16 @@ __metadata:
     "@types/node": "npm:*"
     "@types/responselike": "npm:^1.0.0"
   checksum: 10c0/10816a88e4e5b144d43c1d15a81003f86d649776c7f410c9b5e6579d0ad9d4ca71c541962fb403077388b446e41af7ae38d313e46692144985f006ac5e11fa03
+  languageName: node
+  linkType: hard
+
+"@types/chai@npm:^5.2.2":
+  version: 5.2.3
+  resolution: "@types/chai@npm:5.2.3"
+  dependencies:
+    "@types/deep-eql": "npm:*"
+    assertion-error: "npm:^2.0.1"
+  checksum: 10c0/e0ef1de3b6f8045a5e473e867c8565788c444271409d155588504840ad1a53611011f85072188c2833941189400228c1745d78323dac13fcede9c2b28bacfb2f
   languageName: node
   linkType: hard
 
@@ -5216,6 +5588,13 @@ __metadata:
   dependencies:
     "@types/ms": "npm:*"
   checksum: 10c0/5dcd465edbb5a7f226e9a5efd1f399c6172407ef5840686b73e3608ce135eeca54ae8037dcd9f16bdb2768ac74925b820a8b9ecc588a58ca09eca6acabe33e2f
+  languageName: node
+  linkType: hard
+
+"@types/deep-eql@npm:*":
+  version: 4.0.2
+  resolution: "@types/deep-eql@npm:4.0.2"
+  checksum: 10c0/bf3f811843117900d7084b9d0c852da9a044d12eb40e6de73b552598a6843c21291a8a381b0532644574beecd5e3491c5ff3a0365ab86b15d59862c025384844
   languageName: node
   linkType: hard
 
@@ -5571,6 +5950,88 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/expect@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/expect@npm:4.1.10"
+  dependencies:
+    "@standard-schema/spec": "npm:^1.1.0"
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/spy": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
+    chai: "npm:^6.2.2"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/a817ad0d9bd6a039776a7228d54fb8319c17e4af15917407f5566ac61781a8511f591d302519d6999217399915bc3c0290028189fc73f5c38f80cb01b6f19c8d
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/mocker@npm:4.1.10"
+  dependencies:
+    "@vitest/spy": "npm:4.1.10"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^0.30.21"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10c0/4aa70b0df58681652e2e28093437fb2e8f4d02a6d03f5619abc266ac1c5ae5f43326148061d13ae6e071e0f6cfcf7634659af63644de8ce098a7c98949a3d1ad
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/pretty-format@npm:4.1.10"
+  dependencies:
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/1a5daba730ffe23f2000bff484b4b2842f3b178d93663cb487b215516b8d3b62caa3e2bb2a3c63307b61a9fe58fb9bfff38559bc0c5e49d8aa403d6803a1d918
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/runner@npm:4.1.10"
+  dependencies:
+    "@vitest/utils": "npm:4.1.10"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/554b72639de9694271b99be8ae273fe12ec793093ec91cce143816cd1187d40b7138a4d9d4de4f456cfca9567de986825bff97e107c05b9eb4abc130e854286d
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/snapshot@npm:4.1.10"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
+    magic-string: "npm:^0.30.21"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/e71398725f51af5fd0c07bb4b957d0f987daf9b4c564ac24cb2a4d1afde1a6939f535ac17761a32dcc41b0a1e6d4088af66dc44df89fdebebb92aabed1a92b5f
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/spy@npm:4.1.10"
+  checksum: 10c0/e5c08012560af6727fd66741c5cda25560d7c5442103d0c83e4276a9b0dd90b9da6cdf823a461195229a16c6ff87768ce788a68d0fa29dea73ee285618668178
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:4.1.10":
+  version: 4.1.10
+  resolution: "@vitest/utils@npm:4.1.10"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.10"
+    convert-source-map: "npm:^2.0.0"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/05b0ecec6997ec22fc08377e57dbd8fa37992e05961f3a7a916d98b1ab56d15c2a87dbd83d392b628242bdc156b1705e7fa60a3bf0c54bdb51158c153e05fc5d
+  languageName: node
+  linkType: hard
+
 "@xmldom/xmldom@npm:^0.8.8":
   version: 0.8.11
   resolution: "@xmldom/xmldom@npm:0.8.11"
@@ -5707,6 +6168,13 @@ __metadata:
   dependencies:
     color-convert: "npm:^2.0.1"
   checksum: 10c0/895a23929da416f2bd3de7e9cb4eabd340949328ab85ddd6e484a637d8f6820d485f53933446f5291c3b760cbc488beb8e88573dd0f9c7daf83dccc8fe81b041
+  languageName: node
+  linkType: hard
+
+"ansi-styles@npm:^5.0.0":
+  version: 5.2.0
+  resolution: "ansi-styles@npm:5.2.0"
+  checksum: 10c0/9c4ca80eb3c2fb7b33841c210d2f20807f40865d27008d7c3f707b7f95cab7d67462a565e2388ac3285b71cb3d9bb2173de8da37c57692a362885ec34d6e27df
   languageName: node
   linkType: hard
 
@@ -5876,7 +6344,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"aria-query@npm:^5.3.2":
+"aria-query@npm:5.3.0":
+  version: 5.3.0
+  resolution: "aria-query@npm:5.3.0"
+  dependencies:
+    dequal: "npm:^2.0.3"
+  checksum: 10c0/2bff0d4eba5852a9dd578ecf47eaef0e82cc52569b48469b0aac2db5145db0b17b7a58d9e01237706d1e14b7a1b0ac9b78e9c97027ad97679dd8f91b85da1469
+  languageName: node
+  linkType: hard
+
+"aria-query@npm:^5.0.0, aria-query@npm:^5.3.2":
   version: 5.3.2
   resolution: "aria-query@npm:5.3.2"
   checksum: 10c0/003c7e3e2cff5540bf7a7893775fc614de82b0c5dde8ae823d47b7a28a9d4da1f7ed85f340bdb93d5649caa927755f0e31ecc7ab63edfdfc00c8ef07e505e03e
@@ -6011,6 +6488,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10c0/bbbcb117ac6480138f8c93cf7f535614282dea9dc828f540cdece85e3c665e8f78958b96afac52f29ff883c72638e6a87d469ecc9fe5bc902df03ed24a55dba8
+  languageName: node
+  linkType: hard
+
 "assign-symbols@npm:^1.0.0":
   version: 1.0.0
   resolution: "assign-symbols@npm:1.0.0"
@@ -6142,6 +6626,15 @@ __metadata:
   bin:
     baseline-browser-mapping: dist/cli.js
   checksum: 10c0/500af82926d71d23fab20bcf821eb27deeaad45d1a01bd33d2dea7aab6114149068fa0d42bb9c5c18657e996b6e8063b84612c8fb8ac8ba6c6c6028fa4930ed1
+  languageName: node
+  linkType: hard
+
+"bidi-js@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "bidi-js@npm:1.0.3"
+  dependencies:
+    require-from-string: "npm:^2.0.2"
+  checksum: 10c0/fdddea4aa4120a34285486f2267526cd9298b6e8b773ad25e765d4f104b6d7437ab4ba542e6939e3ac834a7570bcf121ee2cf6d3ae7cd7082c4b5bedc8f271e1
   languageName: node
   linkType: hard
 
@@ -6453,6 +6946,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chai@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "chai@npm:6.2.2"
+  checksum: 10c0/e6c69e5f0c11dffe6ea13d0290936ebb68fcc1ad688b8e952e131df6a6d5797d5e860bc55cef1aca2e950c3e1f96daf79e9d5a70fb7dbaab4e46355e2635ed53
+  languageName: node
+  linkType: hard
+
 "chalk-template@npm:^0.4.0":
   version: 0.4.0
   resolution: "chalk-template@npm:0.4.0"
@@ -6569,6 +7069,10 @@ __metadata:
     "@react-spring/web": "npm:^10.0.3"
     "@tanstack/eslint-plugin-query": "npm:^5.101.2"
     "@tanstack/react-query": "npm:^5.90.12"
+    "@testing-library/dom": "npm:^10.4.1"
+    "@testing-library/jest-dom": "npm:^7.0.0"
+    "@testing-library/react": "npm:^16.3.2"
+    "@testing-library/user-event": "npm:^14.6.1"
     "@tiptap/extension-placeholder": "npm:^3.22.5"
     "@tiptap/extension-text-align": "npm:^3.22.5"
     "@tiptap/extension-text-style": "npm:^3.22.5"
@@ -6607,6 +7111,7 @@ __metadata:
     html-react-parser: "npm:^5.2.10"
     immer: "npm:^11.0.1"
     javascript-color-gradient: "npm:^2.5.0"
+    jsdom: "npm:^30.0.1"
     jszip: "npm:^3.10.1"
     maplibre-gl: "npm:^5.24.0"
     path-browserify: "npm:^1.0.1"
@@ -6625,6 +7130,7 @@ __metadata:
     vite: "npm:^8.1.5"
     vite-plugin-svgr: "npm:^5.2.0"
     vite-tsconfig-paths: "npm:^6.1.1"
+    vitest: "npm:^4.1.10"
     wait-on: "npm:^9.0.3"
     zustand: "npm:^5.0.9"
   languageName: unknown
@@ -6961,6 +7467,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"css-tree@npm:^3.0.0, css-tree@npm:^3.2.1":
+  version: 3.2.1
+  resolution: "css-tree@npm:3.2.1"
+  dependencies:
+    mdn-data: "npm:2.27.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/1f65e9ccaa56112a4706d6f003dd43d777f0dbcf848e66fd320f823192533581f8dd58daa906cb80622658332d50284d6be13b87a6ab4556cbbfe9ef535bbf7e
+  languageName: node
+  linkType: hard
+
+"css.escape@npm:^1.5.1":
+  version: 1.5.1
+  resolution: "css.escape@npm:1.5.1"
+  checksum: 10c0/5e09035e5bf6c2c422b40c6df2eb1529657a17df37fda5d0433d722609527ab98090baf25b13970ca754079a0f3161dd3dfc0e743563ded8cfa0749d861c1525
+  languageName: node
+  linkType: hard
+
 "csstype@npm:^3.1.3, csstype@npm:^3.2.2":
   version: 3.2.3
   resolution: "csstype@npm:3.2.3"
@@ -7092,6 +7615,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"data-urls@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "data-urls@npm:7.0.0"
+  dependencies:
+    whatwg-mimetype: "npm:^5.0.0"
+    whatwg-url: "npm:^16.0.0"
+  checksum: 10c0/08d88ef50d8966a070ffdaa703e1e4b29f01bb2da364dfbc1612b1c2a4caa8045802c9532d81347b21781100132addb36a585071c8323b12cce97973961dee9f
+  languageName: node
+  linkType: hard
+
 "data-view-buffer@npm:^1.0.2":
   version: 1.0.2
   resolution: "data-view-buffer@npm:1.0.2"
@@ -7169,6 +7702,13 @@ __metadata:
     supports-color:
       optional: true
   checksum: 10c0/1471db19c3b06d485a622d62f65947a19a23fbd0dd73f7fd3eafb697eec5360cde447fb075919987899b1a2096e85d35d4eb5a4de09a57600ac9cf7e6c8e768b
+  languageName: node
+  linkType: hard
+
+"decimal.js@npm:^10.6.0":
+  version: 10.6.0
+  resolution: "decimal.js@npm:10.6.0"
+  checksum: 10c0/07d69fbcc54167a340d2d97de95f546f9ff1f69d2b45a02fd7a5292412df3cd9eb7e23065e532a318f5474a2e1bccf8392fdf0443ef467f97f3bf8cb0477e5aa
   languageName: node
   linkType: hard
 
@@ -7286,7 +7826,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"dequal@npm:^2.0.0":
+"dequal@npm:^2.0.0, dequal@npm:^2.0.3":
   version: 2.0.3
   resolution: "dequal@npm:2.0.3"
   checksum: 10c0/f98860cdf58b64991ae10205137c0e97d384c3a4edc7f807603887b7c4b850af1224a33d88012009f150861cbee4fa2d322c4cc04b9313bee312e47f6ecaa888
@@ -7361,6 +7901,20 @@ __metadata:
   dependencies:
     esutils: "npm:^2.0.2"
   checksum: 10c0/b6416aaff1f380bf56c3b552f31fdf7a69b45689368deca72d28636f41c16bb28ec3ebc40ace97db4c1afc0ceeb8120e8492fe0046841c94c2933b2e30a7d5ac
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.5.9":
+  version: 0.5.16
+  resolution: "dom-accessibility-api@npm:0.5.16"
+  checksum: 10c0/b2c2eda4fae568977cdac27a9f0c001edf4f95a6a6191dfa611e3721db2478d1badc01db5bb4fa8a848aeee13e442a6c2a4386d65ec65a1436f24715a2f8d053
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.6.3":
+  version: 0.6.3
+  resolution: "dom-accessibility-api@npm:0.6.3"
+  checksum: 10c0/10bee5aa514b2a9a37c87cd81268db607a2e933a050074abc2f6fa3da9080ebed206a320cbc123567f2c3087d22292853bdfdceaffdd4334ffe2af9510b29360
   languageName: node
   linkType: hard
 
@@ -7625,6 +8179,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"entities@npm:^8.0.0":
+  version: 8.0.0
+  resolution: "entities@npm:8.0.0"
+  checksum: 10c0/938e631664c19451823344a351aeeafd74fae2d5fa51e4d5b6ff635afaefd4bacf0f609989888c04c42733f46ffdac15211608267ebb02488005891a4793e94d
+  languageName: node
+  linkType: hard
+
 "env-paths@npm:^2.2.0":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
@@ -7752,6 +8313,13 @@ __metadata:
     iterator.prototype: "npm:^1.1.5"
     safe-array-concat: "npm:^1.1.3"
   checksum: 10c0/1ced8abf845a45e660dd77b5f3a64358421df70e4a0bd1897d5ddfefffed8409a6a2ca21241b9367e639df9eca74abc1c678b3020bffe6bee1f1826393658ddb
+  languageName: node
+  linkType: hard
+
+"es-module-lexer@npm:^2.0.0":
+  version: 2.3.1
+  resolution: "es-module-lexer@npm:2.3.1"
+  checksum: 10c0/ada8b222772b5b8ea92eb6054c383233207418621855a07b480fdd36979b658a41414be09e793fcdd8a67a182741475f47830a01ff2ebd4353d7f6965c7c45f9
   languageName: node
   linkType: hard
 
@@ -8186,10 +8754,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "estree-walker@npm:3.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+  checksum: 10c0/c12e3c2b2642d2bcae7d5aa495c60fa2f299160946535763969a1c83fc74518ffa9c2cd3a8b69ac56aea547df6a8aac25f729a342992ef0bbac5f1c73e78995d
+  languageName: node
+  linkType: hard
+
 "esutils@npm:^2.0.2":
   version: 2.0.3
   resolution: "esutils@npm:2.0.3"
   checksum: 10c0/9a2fe69a41bfdade834ba7c42de4723c97ec776e40656919c62cbd13607c45e127a003f05f724a1ea55e5029a4cf2de444b13009f2af71271e42d93a637137c7
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.3.0":
+  version: 1.4.0
+  resolution: "expect-type@npm:1.4.0"
+  checksum: 10c0/d40d76b8570695d36587beb3cc28494da2ca3ec8f04e67f5622ed2d372d850e401a9adef19c6835e1a8173903f157c79540b34c7b3fbd7cd8ce726cc903c57b7
   languageName: node
   linkType: hard
 
@@ -8982,6 +9566,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"html-encoding-sniffer@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "html-encoding-sniffer@npm:6.0.0"
+  dependencies:
+    "@exodus/bytes": "npm:^1.6.0"
+  checksum: 10c0/66dc3f6f5539cc3beb814fcbfae7eacf4ec38cf824d6e1425b72039b51a40f4456bd8541ba66f4f4fe09cdf885ab5cd5bae6ec6339d6895a930b2fdb83c53025
+  languageName: node
+  linkType: hard
+
 "html-react-parser@npm:^5.2.10":
   version: 5.2.10
   resolution: "html-react-parser@npm:5.2.10"
@@ -9494,6 +10087,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-potential-custom-element-name@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "is-potential-custom-element-name@npm:1.0.1"
+  checksum: 10c0/b73e2f22bc863b0939941d369486d308b43d7aef1f9439705e3582bfccaa4516406865e32c968a35f97a99396dac84e2624e67b0a16b0a15086a785e16ce7db9
+  languageName: node
+  linkType: hard
+
 "is-regex@npm:^1.2.1":
   version: 1.2.1
   resolution: "is-regex@npm:1.2.1"
@@ -9732,6 +10332,40 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jsdom@npm:^30.0.1":
+  version: 30.0.1
+  resolution: "jsdom@npm:30.0.1"
+  dependencies:
+    "@asamuzakjp/css-color": "npm:^6.0.5"
+    "@asamuzakjp/dom-selector": "npm:^8.3.0"
+    "@bramus/specificity": "npm:^2.4.2"
+    "@csstools/css-syntax-patches-for-csstree": "npm:^1.1.7"
+    "@exodus/bytes": "npm:^1.15.1"
+    css-tree: "npm:^3.2.1"
+    data-urls: "npm:^7.0.0"
+    decimal.js: "npm:^10.6.0"
+    html-encoding-sniffer: "npm:^6.0.0"
+    is-potential-custom-element-name: "npm:^1.0.1"
+    lru-cache: "npm:^11.5.2"
+    parse5: "npm:^8.0.1"
+    saxes: "npm:^6.0.0"
+    symbol-tree: "npm:^3.2.4"
+    tough-cookie: "npm:^6.0.2"
+    undici: "npm:^8.9.0"
+    w3c-xmlserializer: "npm:^5.0.0"
+    webidl-conversions: "npm:^8.0.1"
+    whatwg-mimetype: "npm:^5.0.0"
+    whatwg-url: "npm:^17.1.0"
+    xml-name-validator: "npm:^5.0.0"
+  peerDependencies:
+    canvas: ^3.2.3
+  peerDependenciesMeta:
+    canvas:
+      optional: true
+  checksum: 10c0/2e3c04c30da46f373259b33ffb1a7786d351370aada3bfa3d7766dc97956659727dc78f49e01813b313e873d32851c842dc319b89d099f9e9decb55339dca155
+  languageName: node
+  linkType: hard
+
 "jsep@npm:^0.3.0":
   version: 0.3.5
   resolution: "jsep@npm:0.3.5"
@@ -9963,9 +10597,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-android-arm64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-android-arm64@npm:1.33.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "lightningcss-darwin-arm64@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-darwin-arm64@npm:1.32.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-arm64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-darwin-arm64@npm:1.33.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
@@ -9977,9 +10625,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-darwin-x64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-darwin-x64@npm:1.33.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
 "lightningcss-freebsd-x64@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-freebsd-x64@npm:1.32.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-freebsd-x64@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-freebsd-x64@npm:1.33.0"
   conditions: os=freebsd & cpu=x64
   languageName: node
   linkType: hard
@@ -9991,9 +10653,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-linux-arm-gnueabihf@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.33.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
 "lightningcss-linux-arm64-gnu@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-linux-arm64-gnu@npm:1.32.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-gnu@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm64-gnu@npm:1.33.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
@@ -10005,9 +10681,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-linux-arm64-musl@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-arm64-musl@npm:1.33.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "lightningcss-linux-x64-gnu@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-linux-x64-gnu@npm:1.32.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-gnu@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-x64-gnu@npm:1.33.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
@@ -10019,6 +10709,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-linux-x64-musl@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-linux-x64-musl@npm:1.33.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
 "lightningcss-win32-arm64-msvc@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-win32-arm64-msvc@npm:1.32.0"
@@ -10026,9 +10723,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lightningcss-win32-arm64-msvc@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-win32-arm64-msvc@npm:1.33.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
 "lightningcss-win32-x64-msvc@npm:1.32.0":
   version: 1.32.0
   resolution: "lightningcss-win32-x64-msvc@npm:1.32.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-x64-msvc@npm:1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss-win32-x64-msvc@npm:1.33.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -10073,6 +10784,49 @@ __metadata:
     lightningcss-win32-x64-msvc:
       optional: true
   checksum: 10c0/70945bd55097af46fc9fab7f5ed09cd5869d85940a2acab7ee06d0117004a1d68155708a2d462531cea2fc3c67aefc9333a7068c80b0b78dd404c16838809e03
+  languageName: node
+  linkType: hard
+
+"lightningcss@npm:^1.33.0":
+  version: 1.33.0
+  resolution: "lightningcss@npm:1.33.0"
+  dependencies:
+    detect-libc: "npm:^2.0.3"
+    lightningcss-android-arm64: "npm:1.33.0"
+    lightningcss-darwin-arm64: "npm:1.33.0"
+    lightningcss-darwin-x64: "npm:1.33.0"
+    lightningcss-freebsd-x64: "npm:1.33.0"
+    lightningcss-linux-arm-gnueabihf: "npm:1.33.0"
+    lightningcss-linux-arm64-gnu: "npm:1.33.0"
+    lightningcss-linux-arm64-musl: "npm:1.33.0"
+    lightningcss-linux-x64-gnu: "npm:1.33.0"
+    lightningcss-linux-x64-musl: "npm:1.33.0"
+    lightningcss-win32-arm64-msvc: "npm:1.33.0"
+    lightningcss-win32-x64-msvc: "npm:1.33.0"
+  dependenciesMeta:
+    lightningcss-android-arm64:
+      optional: true
+    lightningcss-darwin-arm64:
+      optional: true
+    lightningcss-darwin-x64:
+      optional: true
+    lightningcss-freebsd-x64:
+      optional: true
+    lightningcss-linux-arm-gnueabihf:
+      optional: true
+    lightningcss-linux-arm64-gnu:
+      optional: true
+    lightningcss-linux-arm64-musl:
+      optional: true
+    lightningcss-linux-x64-gnu:
+      optional: true
+    lightningcss-linux-x64-musl:
+      optional: true
+    lightningcss-win32-arm64-msvc:
+      optional: true
+    lightningcss-win32-x64-msvc:
+      optional: true
+  checksum: 10c0/ce1f8279fbae636dbf37fa6e7385d5f98ed881d72af3362f24afbd4685e19c1fcdfecf17e5dd77f2ebee3d0c23ade276230d85842d07292229a2cffba8ff20a3
   languageName: node
   linkType: hard
 
@@ -10206,6 +10960,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^11.5.2":
+  version: 11.5.2
+  resolution: "lru-cache@npm:11.5.2"
+  checksum: 10c0/ece1ad731f5b655e85d67047d04bfc13823dc77aa61c5454924a9869ba600a0104e39cc33d726021feef812bc347ca34a5608a5eb1972a5dd0870b7ecd42c3f2
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^5.1.1":
   version: 5.1.1
   resolution: "lru-cache@npm:5.1.1"
@@ -10231,10 +10992,28 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lz-string@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "lz-string@npm:1.5.0"
+  bin:
+    lz-string: bin/bin.js
+  checksum: 10c0/36128e4de34791838abe979b19927c26e67201ca5acf00880377af7d765b38d1c60847e01c5ec61b1a260c48029084ab3893a3925fd6e48a04011364b089991b
+  languageName: node
+  linkType: hard
+
 "lz4js@npm:^0.2.0":
   version: 0.2.0
   resolution: "lz4js@npm:0.2.0"
   checksum: 10c0/73c6dd5117a6fa465e6be1bd5ae34ef4f02e4eb164a47d77f8c2483ccdde43cbdf8509a5e5a4480ef812e5c7a2cb946e026b9c784533775ee5c91861edaefb39
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.30.21":
+  version: 0.30.21
+  resolution: "magic-string@npm:0.30.21"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.5"
+  checksum: 10c0/299378e38f9a270069fc62358522ddfb44e94244baa0d6a8980ab2a9b2490a1d03b236b447eee309e17eb3bddfa482c61259d47960eb018a904f0ded52780c4a
   languageName: node
   linkType: hard
 
@@ -10540,6 +11319,13 @@ __metadata:
   dependencies:
     "@types/mdast": "npm:^4.0.0"
   checksum: 10c0/2d3c1af29bf3fe9c20f552ee9685af308002488f3b04b12fa66652c9718f66f41a32f8362aa2d770c3ff464c034860b41715902ada2306bb0a055146cef064d7
+  languageName: node
+  linkType: hard
+
+"mdn-data@npm:2.27.1":
+  version: 2.27.1
+  resolution: "mdn-data@npm:2.27.1"
+  checksum: 10c0/eb8abf5d22e4d1e090346f5e81b67d23cef14c83940e445da5c44541ad874dc8fb9f6ca236e8258c3a489d9fb5884188a4d7d58773adb9089ac2c0b966796393
   languageName: node
   linkType: hard
 
@@ -10918,6 +11704,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"min-indent@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "min-indent@npm:1.0.1"
+  checksum: 10c0/7e207bd5c20401b292de291f02913230cb1163abca162044f7db1d951fa245b174dc00869d40dd9a9f32a885ad6a5f3e767ee104cf278f399cb4e92d3f582d5c
+  languageName: node
+  linkType: hard
+
 "minimatch@npm:^10.0.0, minimatch@npm:^10.1.1":
   version: 10.1.1
   resolution: "minimatch@npm:10.1.1"
@@ -11142,7 +11935,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.12":
+"nanoid@npm:^3.3.12, nanoid@npm:^3.3.16":
   version: 3.3.16
   resolution: "nanoid@npm:3.3.16"
   bin:
@@ -11356,6 +12149,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"obug@npm:^2.1.1":
+  version: 2.1.4
+  resolution: "obug@npm:2.1.4"
+  checksum: 10c0/34a0ee97cd88573cfd97d384c2a79f07118ae5680d7e45d1de6e99c74eddefe145e8ca27a2db02195a1ee5fded5aa22b924869c842728c201b9f109a27d0ef19
+  languageName: node
+  linkType: hard
+
 "once@npm:^1.3.0, once@npm:^1.3.1, once@npm:^1.4.0":
   version: 1.4.0
   resolution: "once@npm:1.4.0"
@@ -11523,6 +12323,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"parse5@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "parse5@npm:8.0.1"
+  dependencies:
+    entities: "npm:^8.0.0"
+  checksum: 10c0/c3c1c5aab55f6e4be5245599790e56e64be7764a4a0edd7f98db4fe3bb380f63add752fa047dff0496446c25f4104f0c7c1967723de640bde92306a7bb67ed2f
+  languageName: node
+  linkType: hard
+
 "path-browserify@npm:^1.0.1":
   version: 1.0.1
   resolution: "path-browserify@npm:1.0.1"
@@ -11592,6 +12401,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "pathe@npm:2.0.3"
+  checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
+  languageName: node
+  linkType: hard
+
 "pbf@npm:^3.2.1":
   version: 3.3.0
   resolution: "pbf@npm:3.3.0"
@@ -11633,7 +12449,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^1.1.1":
+"picocolors@npm:1.1.1, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
   checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
@@ -11709,6 +12525,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"postcss@npm:^8.5.23":
+  version: 8.5.25
+  resolution: "postcss@npm:8.5.25"
+  dependencies:
+    nanoid: "npm:^3.3.16"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/0a12c1e74b456c57122e81f684e02fd98ff4d57526f794d10c996df1147158808f5ae373ac82b988c8de6cbbaa82dbd7b13803b14f5dd3cf7cc6a42ccad5c9f2
+  languageName: node
+  linkType: hard
+
 "potpack@npm:^2.1.0":
   version: 2.1.0
   resolution: "potpack@npm:2.1.0"
@@ -11745,6 +12572,17 @@ __metadata:
   bin:
     prettier: bin/prettier.cjs
   checksum: 10c0/9675d2cd08eacb1faf1d1a2dbfe24bfab6a912b059fc9defdb380a408893d88213e794a40a2700bd29b140eb3172e0b07c852853f6e22f16f3374659a1a13389
+  languageName: node
+  linkType: hard
+
+"pretty-format@npm:^27.0.2":
+  version: 27.5.1
+  resolution: "pretty-format@npm:27.5.1"
+  dependencies:
+    ansi-regex: "npm:^5.0.1"
+    ansi-styles: "npm:^5.0.0"
+    react-is: "npm:^17.0.1"
+  checksum: 10c0/0cbda1031aa30c659e10921fa94e0dd3f903ecbbbe7184a729ad66f2b6e7f17891e8c7d7654c458fa4ccb1a411ffb695b4f17bbcd3fe075fabe181027c4040ed
   languageName: node
   linkType: hard
 
@@ -11964,7 +12802,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"punycode@npm:^2.1.0":
+"punycode@npm:^2.1.0, punycode@npm:^2.3.1":
   version: 2.3.1
   resolution: "punycode@npm:2.3.1"
   checksum: 10c0/14f76a8206bc3464f794fb2e3d3cc665ae416c01893ad7a02b23766eb07159144ee612ad67af5e84fa4479ccfe67678c4feb126b0485651b302babf66f04f9e9
@@ -12081,6 +12919,13 @@ __metadata:
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 10c0/33977da7a5f1a287936a0c85639fec6ca74f4f15ef1e59a6bc20338fc73dc69555381e211f7a3529b8150a1f71e4225525b41b60b52965bda53ce7d47377ada1
+  languageName: node
+  linkType: hard
+
+"react-is@npm:^17.0.1":
+  version: 17.0.2
+  resolution: "react-is@npm:17.0.2"
+  checksum: 10c0/2bdb6b93fbb1820b024b496042cce405c57e2f85e777c9aabd55f9b26d145408f9f74f5934676ffdc46f3dcff656d78413a6e43968e7b3f92eea35b3052e9053
   languageName: node
   linkType: hard
 
@@ -12213,6 +13058,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"redent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redent@npm:3.0.0"
+  dependencies:
+    indent-string: "npm:^4.0.0"
+    strip-indent: "npm:^3.0.0"
+  checksum: 10c0/d64a6b5c0b50eb3ddce3ab770f866658a2b9998c678f797919ceb1b586bab9259b311407280bd80b804e2a7c7539b19238ae6a2a20c843f1a7fcff21d48c2eae
+  languageName: node
+  linkType: hard
+
 "refa@npm:^0.12.0, refa@npm:^0.12.1":
   version: 0.12.1
   resolution: "refa@npm:0.12.1"
@@ -12334,6 +13189,13 @@ __metadata:
   version: 2.1.1
   resolution: "require-directory@npm:2.1.1"
   checksum: 10c0/83aa76a7bc1531f68d92c75a2ca2f54f1b01463cb566cf3fbc787d0de8be30c9dbc211d1d46be3497dac5785fe296f2dd11d531945ac29730643357978966e99
+  languageName: node
+  linkType: hard
+
+"require-from-string@npm:^2.0.2":
+  version: 2.0.2
+  resolution: "require-from-string@npm:2.0.2"
+  checksum: 10c0/aaa267e0c5b022fc5fd4eef49d8285086b15f2a1c54b28240fdf03599cbd9c26049fee3eab894f2e1f6ca65e513b030a7c264201e3f005601e80c49fb2937ce2
   languageName: node
   linkType: hard
 
@@ -12537,6 +13399,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rolldown@npm:~1.2.0":
+  version: 1.2.1
+  resolution: "rolldown@npm:1.2.1"
+  dependencies:
+    "@oxc-project/types": "npm:=0.142.0"
+    "@rolldown/binding-android-arm64": "npm:1.2.1"
+    "@rolldown/binding-darwin-arm64": "npm:1.2.1"
+    "@rolldown/binding-darwin-x64": "npm:1.2.1"
+    "@rolldown/binding-freebsd-x64": "npm:1.2.1"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.2.1"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.2.1"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.2.1"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.2.1"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.2.1"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.2.1"
+    "@rolldown/binding-linux-x64-musl": "npm:1.2.1"
+    "@rolldown/binding-openharmony-arm64": "npm:1.2.1"
+    "@rolldown/binding-wasm32-wasi": "npm:1.2.1"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.2.1"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.2.1"
+    "@rolldown/pluginutils": "npm:^1.0.0"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-wasm32-wasi":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: ./bin/cli.mjs
+  checksum: 10c0/d22c80c70d71a36abde7dca7217f66d94cdb5d0c03185205de808d368ab1b8fd5e78ff4db10efc69c5f68a5f9d03d59c8ace848f1f85c4aab79330162a10b3e7
+  languageName: node
+  linkType: hard
+
 "rope-sequence@npm:^1.3.0":
   version: 1.3.4
   resolution: "rope-sequence@npm:1.3.4"
@@ -12628,6 +13548,15 @@ __metadata:
   version: 1.4.3
   resolution: "sax@npm:1.4.3"
   checksum: 10c0/45bba07561d93f184a8686e1a543418ced8c844b994fbe45cc49d5cd2fc8ac7ec949dae38565e35e388ad0cca2b75997a29b6857c927bf6553da3f80ed0e4e62
+  languageName: node
+  linkType: hard
+
+"saxes@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "saxes@npm:6.0.0"
+  dependencies:
+    xmlchars: "npm:^2.2.0"
+  checksum: 10c0/3847b839f060ef3476eb8623d099aa502ad658f5c40fd60c105ebce86d244389b0d76fcae30f4d0c728d7705ceb2f7e9b34bb54717b6a7dbedaf5dad2d9a4b74
   languageName: node
   linkType: hard
 
@@ -12825,6 +13754,13 @@ __metadata:
     side-channel-map: "npm:^1.0.1"
     side-channel-weakmap: "npm:^1.0.2"
   checksum: 10c0/cb20dad41eb032e6c24c0982e1e5a24963a28aa6122b4f05b3f3d6bf8ae7fd5474ef382c8f54a6a3ab86e0cac4d41a23bd64ede3970e5bfb50326ba02a7996e6
+  languageName: node
+  linkType: hard
+
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
   languageName: node
   linkType: hard
 
@@ -13047,10 +13983,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
+  languageName: node
+  linkType: hard
+
 "stat-mode@npm:^1.0.0":
   version: 1.0.0
   resolution: "stat-mode@npm:1.0.0"
   checksum: 10c0/89b66a538dbfd45038fefdaf5b2104dc6e911605af1c201793e9629592ed9fdc7bdd1bca42806d0d4167c6d9cacac1f3fda41ddfe334a5c1f898113da38fae74
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^4.0.0-rc.1":
+  version: 4.2.0
+  resolution: "std-env@npm:4.2.0"
+  checksum: 10c0/40ac525ce7b7c556abc332a7376f14356eeb1a7f17f6ff9a003eb9f52326ff1f3745d3e1b43452675b1ec6fcc319f1b1d6f3b0d386cf3f91058479ad883cff69
   languageName: node
   linkType: hard
 
@@ -13226,6 +14176,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"strip-indent@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "strip-indent@npm:3.0.0"
+  dependencies:
+    min-indent: "npm:^1.0.0"
+  checksum: 10c0/ae0deaf41c8d1001c5d4fbe16cb553865c1863da4fae036683b474fa926af9fc121e155cb3fc57a68262b2ae7d5b8420aa752c97a6428c315d00efe2a3875679
+  languageName: node
+  linkType: hard
+
 "strip-json-comments@npm:^3.1.1":
   version: 3.1.1
   resolution: "strip-json-comments@npm:3.1.1"
@@ -13314,6 +14273,13 @@ __metadata:
   dependencies:
     tinyqueue: "npm:^2.0.0"
   checksum: 10c0/587a597c75b787e61054ef88b98463af47f60855265b7829fa8acc5ebe68fb4bc3d148a80e9f72c69c16a0241bfed38d3fbbe93a735ea5a2276c00116adc5283
+  languageName: node
+  linkType: hard
+
+"symbol-tree@npm:^3.2.4":
+  version: 3.2.4
+  resolution: "symbol-tree@npm:3.2.4"
+  checksum: 10c0/dfbe201ae09ac6053d163578778c53aa860a784147ecf95705de0cd23f42c851e1be7889241495e95c37cabb058edb1052f141387bef68f705afc8f9dd358509
   languageName: node
   linkType: hard
 
@@ -13415,6 +14381,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10c0/c3500b0f60d2eb8db65250afe750b66d51623057ee88720b7f064894a6cb7eb93360ca824a60a31ab16dab30c7b1f06efe0795b352e37914a9d4bad86386a20c
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^1.0.2":
+  version: 1.3.0
+  resolution: "tinyexec@npm:1.3.0"
+  checksum: 10c0/e9b89f97489d2aab2cef408da279e6b32547e738d1275032ccb8fd0028a006d93eb70fc51c6cffd9fc2f5aca6c2a273d8b6f73b52d46ee5116da6b94969ef958
+  languageName: node
+  linkType: hard
+
 "tinyglobby@npm:^0.2.12":
   version: 0.2.15
   resolution: "tinyglobby@npm:0.2.15"
@@ -13446,6 +14426,31 @@ __metadata:
   version: 3.0.0
   resolution: "tinyqueue@npm:3.0.0"
   checksum: 10c0/edd6f1a6146aa3aa7bc85b44b3aacf44cddfa805b0901019272d7e9235894b4f28b2f9d09c1bce500ae48883b03708b6b871aa33920e895d2943720f7a9ad3ba
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^3.1.0":
+  version: 3.1.1
+  resolution: "tinyrainbow@npm:3.1.1"
+  checksum: 10c0/f9d2743832c6191f753408f36224fe817620b8abcef572b2e570204c673a901d753ff84ca8e7b88f9c79e934295b3ffc6fcbc56a06f126e24e1ec6186dcad40d
+  languageName: node
+  linkType: hard
+
+"tldts-core@npm:^7.4.10":
+  version: 7.4.10
+  resolution: "tldts-core@npm:7.4.10"
+  checksum: 10c0/a5f42aad8aa8adfc57d33e9bd5c43094e9de226dce4851867ea7014d8679040b4c01c500b9947595ab22cdfe9783ea5d88a7c0be2092d19a14f75c7cd4671181
+  languageName: node
+  linkType: hard
+
+"tldts@npm:^7.0.5":
+  version: 7.4.10
+  resolution: "tldts@npm:7.4.10"
+  dependencies:
+    tldts-core: "npm:^7.4.10"
+  bin:
+    tldts: bin/cli.js
+  checksum: 10c0/a9a85d260bd0bfd046794f140667aae0975da4a3aa805d180b0808b672a6fa7de0fc9f36110c3bdeed87ad780e961e1e5bb1ed8b41f8aa3ad5d5fb469e70ba38
   languageName: node
   linkType: hard
 
@@ -13486,6 +14491,24 @@ __metadata:
   bin:
     geo2topo: bin/geo2topo
   checksum: 10c0/fb2ab1137b2082664149fa2346a33fbb1706687b9760ae38f1e8fb9f444226fb0b0e517baf0712f9130244b173ec29a4dcab78f9c0f259770a266481041136ec
+  languageName: node
+  linkType: hard
+
+"tough-cookie@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "tough-cookie@npm:6.0.2"
+  dependencies:
+    tldts: "npm:^7.0.5"
+  checksum: 10c0/5ff521a476a3c540821352125a5d481c8d2fe16035de7e0efda4df120f290c95500a0e9b51ea0aa56343955be482e014c30f5ba73e04b93ba138e4e855cb9e89
+  languageName: node
+  linkType: hard
+
+"tr46@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "tr46@npm:6.0.0"
+  dependencies:
+    punycode: "npm:^2.3.1"
+  checksum: 10c0/83130df2f649228aa91c17754b66248030a3af34911d713b5ea417066fa338aa4bc8668d06bd98aa21a2210f43fc0a3db8b9099e7747fb5830e40e39a6a1058e
   languageName: node
   linkType: hard
 
@@ -13721,6 +14744,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"undici@npm:^8.9.0":
+  version: 8.9.0
+  resolution: "undici@npm:8.9.0"
+  checksum: 10c0/e3d9fa35a9aa8360d9f56e66bd372f451ee053e25066a97fd9fab3816267035660f67870c6d709a58a5411551657af78c4475be5b31c113b04f70251309900d0
+  languageName: node
+  linkType: hard
+
 "unified@npm:^11.0.0":
   version: 11.0.5
   resolution: "unified@npm:11.0.5"
@@ -13952,6 +14982,63 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
+  version: 8.2.0
+  resolution: "vite@npm:8.2.0"
+  dependencies:
+    fsevents: "npm:~2.3.3"
+    lightningcss: "npm:^1.33.0"
+    picomatch: "npm:^4.0.5"
+    postcss: "npm:^8.5.23"
+    rolldown: "npm:~1.2.0"
+    tinyglobby: "npm:^0.2.17"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    "@vitejs/devtools": ^0.4.0
+    esbuild: ^0.27.0 || ^0.28.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    "@vitejs/devtools":
+      optional: true
+    esbuild:
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/bd6a5e7b28973bac06f0e8e54833800e16d1bf38a8aef2acbfea5bbaed6d8fc715fd7cc9b0ec75ef1adbde149bb9167b085c17fe7edcd3a190b4eda16d474e5c
+  languageName: node
+  linkType: hard
+
 "vite@npm:^8.1.5":
   version: 8.1.5
   resolution: "vite@npm:8.1.5"
@@ -14009,10 +15096,87 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vitest@npm:^4.1.10":
+  version: 4.1.10
+  resolution: "vitest@npm:4.1.10"
+  dependencies:
+    "@vitest/expect": "npm:4.1.10"
+    "@vitest/mocker": "npm:4.1.10"
+    "@vitest/pretty-format": "npm:4.1.10"
+    "@vitest/runner": "npm:4.1.10"
+    "@vitest/snapshot": "npm:4.1.10"
+    "@vitest/spy": "npm:4.1.10"
+    "@vitest/utils": "npm:4.1.10"
+    es-module-lexer: "npm:^2.0.0"
+    expect-type: "npm:^1.3.0"
+    magic-string: "npm:^0.30.21"
+    obug: "npm:^2.1.1"
+    pathe: "npm:^2.0.3"
+    picomatch: "npm:^4.0.3"
+    std-env: "npm:^4.0.0-rc.1"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^1.0.2"
+    tinyglobby: "npm:^0.2.15"
+    tinyrainbow: "npm:^3.1.0"
+    vite: "npm:^6.0.0 || ^7.0.0 || ^8.0.0"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@opentelemetry/api": ^1.9.0
+    "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+    "@vitest/browser-playwright": 4.1.10
+    "@vitest/browser-preview": 4.1.10
+    "@vitest/browser-webdriverio": 4.1.10
+    "@vitest/coverage-istanbul": 4.1.10
+    "@vitest/coverage-v8": 4.1.10
+    "@vitest/ui": 4.1.10
+    happy-dom: "*"
+    jsdom: "*"
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@opentelemetry/api":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser-playwright":
+      optional: true
+    "@vitest/browser-preview":
+      optional: true
+    "@vitest/browser-webdriverio":
+      optional: true
+    "@vitest/coverage-istanbul":
+      optional: true
+    "@vitest/coverage-v8":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+    vite:
+      optional: false
+  bin:
+    vitest: ./vitest.mjs
+  checksum: 10c0/ff07294a57f9c62f3b503f7cf88a52ee0753ed26389a49cda430387a3898f39d80af47180b0af19e27acab5bd11ae95706bd4b44ce8befc97d3ae49af6ca4fc1
+  languageName: node
+  linkType: hard
+
 "w3c-keyname@npm:^2.2.0":
   version: 2.2.8
   resolution: "w3c-keyname@npm:2.2.8"
   checksum: 10c0/37cf335c90efff31672ebb345577d681e2177f7ff9006a9ad47c68c5a9d265ba4a7b39d6c2599ceea639ca9315584ce4bd9c9fbf7a7217bfb7a599e71943c4c4
+  languageName: node
+  linkType: hard
+
+"w3c-xmlserializer@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "w3c-xmlserializer@npm:5.0.0"
+  dependencies:
+    xml-name-validator: "npm:^5.0.0"
+  checksum: 10c0/8712774c1aeb62dec22928bf1cdfd11426c2c9383a1a63f2bcae18db87ca574165a0fbe96b312b73652149167ac6c7f4cf5409f2eb101d9c805efe0e4bae798b
   languageName: node
   linkType: hard
 
@@ -14047,10 +15211,46 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webidl-conversions@npm:^8.0.1":
+  version: 8.0.1
+  resolution: "webidl-conversions@npm:8.0.1"
+  checksum: 10c0/3f6f327ca5fa0c065ed8ed0ef3b72f33623376e68f958e9b7bd0df49fdb0b908139ac2338d19fb45bd0e05595bda96cb6d1622222a8b413daa38a17aacc4dd46
+  languageName: node
+  linkType: hard
+
 "wgs84@npm:0.0.0":
   version: 0.0.0
   resolution: "wgs84@npm:0.0.0"
   checksum: 10c0/4f4094c7149fbb50e89ab415aeb2db565c66746be18702ea82ab75c6e6e2a58b552d0898f4b8d6a16bf5824a14917577e46e04a8b20fbf9f09f06d755d381c0b
+  languageName: node
+  linkType: hard
+
+"whatwg-mimetype@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "whatwg-mimetype@npm:5.0.0"
+  checksum: 10c0/eead164fe73a00dd82f817af6fc0bd22e9c273e1d55bf4bc6bdf2da7ad8127fca82ef00ea6a37892f5f5641f8e34128e09508f92126086baba126b9e0d57feb4
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^16.0.0":
+  version: 16.0.1
+  resolution: "whatwg-url@npm:16.0.1"
+  dependencies:
+    "@exodus/bytes": "npm:^1.11.0"
+    tr46: "npm:^6.0.0"
+    webidl-conversions: "npm:^8.0.1"
+  checksum: 10c0/e75565566abf3a2cdbd9f06c965dbcccee6ec4e9f0d3728ad5e08ceb9944279848bcaa211d35a29cb6d2df1e467dd05cfb59fbddf8a0adcd7d0bce9ffb703fd2
+  languageName: node
+  linkType: hard
+
+"whatwg-url@npm:^17.1.0":
+  version: 17.1.0
+  resolution: "whatwg-url@npm:17.1.0"
+  dependencies:
+    "@exodus/bytes": "npm:^1.15.1"
+    tr46: "npm:^6.0.0"
+    webidl-conversions: "npm:^8.0.1"
+  checksum: 10c0/08fe809e90e1d20f6de631c9cdf312623fe5526731dc176ad38967c7d0f34e6e9700cbc0bad5ecd3d5ea8c62737a487883948e85937432f3a598746d8e05e80e
   languageName: node
   linkType: hard
 
@@ -14137,6 +15337,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
+  languageName: node
+  linkType: hard
+
 "word-wrap@npm:^1.2.5":
   version: 1.2.5
   resolution: "word-wrap@npm:1.2.5"
@@ -14195,6 +15407,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"xml-name-validator@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "xml-name-validator@npm:5.0.0"
+  checksum: 10c0/3fcf44e7b73fb18be917fdd4ccffff3639373c7cb83f8fc35df6001fecba7942f1dbead29d91ebb8315e2f2ff786b508f0c9dc0215b6353f9983c6b7d62cb1f5
+  languageName: node
+  linkType: hard
+
 "xml-naming@npm:^0.3.0":
   version: 0.3.0
   resolution: "xml-naming@npm:0.3.0"
@@ -14206,6 +15425,13 @@ __metadata:
   version: 15.1.1
   resolution: "xmlbuilder@npm:15.1.1"
   checksum: 10c0/665266a8916498ff8d82b3d46d3993913477a254b98149ff7cff060d9b7cc0db7cf5a3dae99aed92355254a808c0e2e3ec74ad1b04aa1061bdb8dfbea26c18b8
+  languageName: node
+  linkType: hard
+
+"xmlchars@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "xmlchars@npm:2.2.0"
+  checksum: 10c0/b64b535861a6f310c5d9bfa10834cf49127c71922c297da9d4d1b45eeaae40bf9b4363275876088fbe2667e5db028d2cd4f8ee72eed9bede840a67d57dab7593
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Strip the `/api` prefix from every backend URL across the codebase now that the backend serves routes from the flat root (e.g. `/tools/...` instead of `/api/tools/...`). Also updates the demo client interceptor to use backend-derived `routePrefixes` for demo URL rewriting instead of a hardcoded `/api/` prefix check, and adds `routePrefixes` to the demo store. Deletes the now-redundant `inputEndpoints.json` constants file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated application requests across onboarding, authentication, projects, scenarios, dashboards, maps, tools, databases, uploads, downloads, and canvases to use current service routes.
  * Improved demo-mode routing using route information returned with demo scenarios.
  * Preserved existing validation, error handling, navigation, and data-processing behavior.
* **Documentation**
  * Updated endpoint references throughout the application to match current routes.
* **Tests**
  * Added automated coverage for demo mode, canvas, pathway, routing, and API behavior.
* **Chores**
  * Added continuous integration checks for the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->