### PR TITLE
Consolidate card styles into CSS classes

### DIFF
--- a/src/app/Project.css
+++ b/src/app/Project.css
@@ -38,7 +38,20 @@
 }
 
 .cea-overlay-card {
+  border-radius: 12px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   pointer-events: auto;
+}
+
+.cea-map-controls-card {
+  background-color: rgb(255, 255, 255);
+
+  height: 100%;
+
+  display: flex;
+  align-items: center;
+
+  font-size: 12px;
 }
 
 .cea-tool-card-container {

--- a/src/components/DemoBanner.jsx
+++ b/src/components/DemoBanner.jsx
@@ -13,9 +13,7 @@ const DemoBanner = () => {
     <div
       style={{
         padding: 8,
-        background: '#fff',
-        borderRadius: 9,
-        boxShadow: '0 0 10px rgba(0,0,0,.1)',
+
         fontSize: 12,
         display: 'flex',
         flexDirection: 'column',

--- a/src/components/UserInfo.jsx
+++ b/src/components/UserInfo.jsx
@@ -56,9 +56,6 @@ const UserInfoCard = () => {
     <div
       style={{
         padding: 8,
-        background: '#fff',
-        borderRadius: 9,
-        boxShadow: '0 0 10px rgba(0,0,0,.1)',
       }}
     >
       <div

--- a/src/features/map/components/Map/Layers/ConstructionStandardLegend.jsx
+++ b/src/features/map/components/Map/Layers/ConstructionStandardLegend.jsx
@@ -76,15 +76,12 @@ const ConstructionStandardLegend = ({
     <div
       className="cea-overlay-card construction-standard-legend"
       style={{
-        backgroundColor: 'rgba(255, 255, 255, 0.9)',
-        borderRadius: 12,
-        boxShadow: '0 2px 4px rgba(0, 0, 0, 0.15)',
-        boxSizing: 'border-box',
+        backgroundColor: 'rgb(255, 255, 255)',
+
         display: 'flex',
         flexDirection: 'column',
         fontSize: 12,
         padding: 12,
-        width: 280,
         maxHeight: 200,
         ...style,
       }}

--- a/src/features/map/components/Map/Layers/Legend.jsx
+++ b/src/features/map/components/Map/Layers/Legend.jsx
@@ -312,10 +312,7 @@ const Legend = ({ extras, style }) => {
     <div
       className="cea-overlay-card"
       style={{
-        backgroundColor: 'rgba(255, 255, 255, 0.9)',
-        borderRadius: 12,
-        boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
-
+        backgroundColor: 'rgb(255, 255, 255)',
         boxSizing: 'border-box',
 
         display: 'flex',

--- a/src/features/project/components/Cards/MapLayersCard/MapLayersCard.jsx
+++ b/src/features/project/components/Cards/MapLayersCard/MapLayersCard.jsx
@@ -36,11 +36,9 @@ const MapLayerCategoriesCard = ({ mapLayerCategories, onCategorySelected }) => {
     <div
       className="cea-overlay-card cea-card-toolbar-icon-container inverted"
       style={{
-        backgroundColor: 'rgba(255, 255, 255, 0.8)',
-        borderRadius: 12,
-        boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
-
+        backgroundColor: 'rgb(255, 255, 255)',
         boxSizing: 'border-box',
+
         height: '100%',
 
         display: 'flex',

--- a/src/features/project/components/Cards/OverviewCard/OverviewCard.jsx
+++ b/src/features/project/components/Cards/OverviewCard/OverviewCard.jsx
@@ -47,12 +47,7 @@ const OverviewCard = ({
     <div
       id="cea-overview-card"
       style={{
-        background: '#fff',
         padding: 12,
-        borderRadius: 12,
-        boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
-
-        boxSizing: 'border-box',
 
         display: 'flex',
         flexDirection: 'column',

--- a/src/features/project/components/Cards/ToolCard.jsx
+++ b/src/features/project/components/Cards/ToolCard.jsx
@@ -81,11 +81,6 @@ const ToolCard = ({ onPlotToolSelected }) => {
       <div
         className="cea-tool-card"
         style={{
-          background: '#fff',
-
-          borderRadius: 12,
-          boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)',
-
           height: '100%',
           boxSizing: 'border-box',
           padding: 12,

--- a/src/features/project/components/Cards/ToolCardSideButtons.jsx
+++ b/src/features/project/components/Cards/ToolCardSideButtons.jsx
@@ -24,6 +24,8 @@ export const ToolCardSideButtons = () => {
 
         display: 'flex',
         gap: 8,
+
+        boxShadow: 'none',
       }}
     >
       <Button

--- a/src/features/project/components/Cards/Toolbar/Toolbar.css
+++ b/src/features/project/components/Cards/Toolbar/Toolbar.css
@@ -47,7 +47,7 @@ button.cea-card-toolbar-icon-container {
 
 .cea-card-toolbar-icon-container {
   display: flex;
-  background: #000;
+  background-color: #000;
   color: #fff;
 
   border-radius: 12px;

--- a/src/features/project/components/Cards/input-changes-card.jsx
+++ b/src/features/project/components/Cards/input-changes-card.jsx
@@ -24,12 +24,8 @@ export const InputChangesCard = () => {
       <div
         className="cea-overlay-card"
         style={{
-          background: '#fff',
+          backgroundColor: 'rgb(255, 255, 255)',
           padding: 12,
-          borderRadius: 12,
-          boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
-
-          boxSizing: 'border-box',
 
           display: 'flex',
           flexDirection: 'column',

--- a/src/features/project/components/InputTable.jsx
+++ b/src/features/project/components/InputTable.jsx
@@ -23,7 +23,14 @@ const InputTable = ({ onClose }) => {
   return (
     <div
       className="cea-input-editor"
-      style={{ height: '100%', display: 'flex', flexDirection: 'column' }}
+      style={{
+        boxSizing: 'border-box',
+        padding: 12,
+
+        height: '100%',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
     >
       <Tabs
         className="cea-input-editor-tabs"

--- a/src/features/project/components/ProjectOverlay.jsx
+++ b/src/features/project/components/ProjectOverlay.jsx
@@ -312,53 +312,75 @@ const ProjectOverlay = ({ project, scenarioName }) => {
           </button>
         </>
       )}
-      <div id="cea-project-overlay-left-sidebar">
-        {hideAll && (
-          <div style={{ position: 'absolute', top: 0, left: 0, margin: 12 }}>
-            <ShowHideCardsButton onToggle={handleHideAll} />
-          </div>
-        )}
+      <div
+        id="cea-project-overlay-left-sidebar"
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+        }}
+      >
+        <div>
+          {hideAll && (
+            <div style={{ position: 'absolute', top: 0, left: 0, margin: 12 }}>
+              <ShowHideCardsButton onToggle={handleHideAll} />
+            </div>
+          )}
 
-        {transitionFromLeft((styles, item) =>
-          item ? (
-            <animated.div style={styles}>
-              <div
-                style={{
-                  display: 'flex',
-                  flexDirection: 'column',
-                  gap: 12,
-                  height: '100%',
-                  width: '100%',
-                }}
-              >
-                <div className="cea-overlay-card">
-                  <OverviewCard
-                    project={project}
-                    projectName={name}
-                    scenarioName={scenarioName}
-                    scenarioList={scenarioList}
-                    onToggleHideAll={handleHideAll}
-                  />
+          {transitionFromLeft((styles, item) =>
+            item ? (
+              <animated.div style={styles}>
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 12,
+                    height: '100%',
+                    width: '100%',
+                  }}
+                >
+                  <div
+                    className="cea-overlay-card"
+                    style={{ backgroundColor: 'rgb(255, 255, 255)' }}
+                  >
+                    <OverviewCard
+                      project={project}
+                      projectName={name}
+                      scenarioName={scenarioName}
+                      scenarioList={scenarioList}
+                      onToggleHideAll={handleHideAll}
+                    />
+                  </div>
+
+                  {demoMode && (
+                    <div
+                      className="cea-overlay-card"
+                      style={{ backgroundColor: 'rgb(255, 255, 255)' }}
+                    >
+                      <DemoBanner />
+                    </div>
+                  )}
+
+                  {`${import.meta.env.VITE_AUTH_URL}` && !isElectron() ? (
+                    // FIXME: Login disabled for electron
+                    <div
+                      className="cea-overlay-card"
+                      style={{ backgroundColor: 'rgb(255, 255, 255)' }}
+                    >
+                      <UserInfo />
+                    </div>
+                  ) : null}
+
+                  <InputChangesCard />
                 </div>
+              </animated.div>
+            ) : null,
+          )}
+        </div>
 
-                {demoMode && (
-                  <div className="cea-overlay-card">
-                    <DemoBanner />
-                  </div>
-                )}
-
-                {`${import.meta.env.VITE_AUTH_URL}` && !isElectron() ? (
-                  // FIXME: Login disabled for electron
-                  <div className="cea-overlay-card">
-                    <UserInfo />
-                  </div>
-                ) : null}
-
-                <InputChangesCard />
-              </div>
-            </animated.div>
-          ) : null,
-        )}
+        <div>
+          <ConstructionStandardLegend />
+        </div>
       </div>
 
       <div id="cea-project-overlay-header">
@@ -371,17 +393,6 @@ const ProjectOverlay = ({ project, scenarioName }) => {
         )}
       </div>
 
-      <div
-        className="cea-overlay-card"
-        style={{
-          gridColumn: '1',
-          gridRow: '2',
-          alignSelf: 'end',
-        }}
-      >
-        <ConstructionStandardLegend />
-      </div>
-
       <div id="cea-project-overlay-content" className="overlay-flex-column">
         <MapLayerPropertiesCard onLayerSelect={handleLayerSelected} />
 
@@ -390,13 +401,8 @@ const ProjectOverlay = ({ project, scenarioName }) => {
             <animated.div
               className="cea-overlay-card"
               style={{
+                backgroundColor: 'rgb(255, 255, 255)',
                 ...styles,
-                paddingInline: 12,
-                paddingBottom: 12,
-                borderRadius: 12,
-                boxShadow: '0 0 10px rgba(0, 0, 0, 0.1)',
-
-                background: '#fff',
                 // maxHeight: '40vh',
               }}
             >
@@ -412,9 +418,7 @@ const ProjectOverlay = ({ project, scenarioName }) => {
               style={{
                 ...styles,
                 overflow: 'hidden',
-                borderRadius: 20,
-                boxShadow: '0 24px 54px rgba(15, 23, 42, 0.16)',
-                background: 'rgba(255, 255, 255, 0.94)',
+                backgroundColor: 'rgb(255, 255, 255)',
                 display: pathwayPanelHiddenForTool ? 'none' : 'flex',
                 flexDirection: 'column',
                 height: pathwayPanelExpanded ? 'auto' : pathwayPanelHeight,
@@ -483,7 +487,7 @@ const ProjectOverlay = ({ project, scenarioName }) => {
           item ? (
             <animated.div
               className="cea-overlay-card cea-tool-card-container"
-              style={styles}
+              style={{ backgroundColor: 'rgb(255, 255, 255)', ...styles }}
             >
               <ToolCard onPlotToolSelected={handlePlotToolSelected} />
             </animated.div>
@@ -516,23 +520,7 @@ const ProjectOverlay = ({ project, scenarioName }) => {
               demoMode={demoMode}
             />
           )}
-          <div
-            className="cea-overlay-card"
-            // FIXME: Move to CSS
-            style={{
-              backgroundColor: 'rgba(255, 255, 255, 0.8)',
-              borderRadius: 12,
-              boxShadow: '0 2px 4px rgba(0, 0, 0, 0.1)',
-
-              boxSizing: 'border-box',
-              height: '100%',
-
-              display: 'flex',
-              alignItems: 'center',
-
-              fontSize: 12,
-            }}
-          >
+          <div className="cea-overlay-card cea-map-controls-card">
             <MapControls />
           </div>
 


### PR DESCRIPTION
Move repeated inline styles (border-radius, box-shadow, background) for overlay cards into the `.cea-overlay-card` CSS class. Add a new `.cea-map-controls-card` class for map controls. Remove redundant per-component style declarations and standardize background colors to `rgb(255, 255, 255)`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Refined project map and overlay styling for a cleaner, more consistent appearance.
  - Standardized white backgrounds across legends, cards, panels, and map controls.
  - Removed unnecessary rounded corners and shadows from several interface elements.
  - Improved sidebar layout and positioned the construction legend at the bottom.
  - Updated input editor spacing and sizing for better visual alignment.
  - Simplified toolbar icon background styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->